### PR TITLE
Capture screenshot on whichever display the cursor is on

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requires **macOS 10.13+**, **Node.js 18+**, and **Xcode CLT** (`xcode-select --i
 
 ## How It Works
 
-1. **Cmd+Shift+2** — Fullscreen overlay appears, drag to select a region
+1. **Cmd+Shift+2** — Fullscreen overlay appears on whichever display the cursor is on, drag to select a region
 2. **Annotate** — Rectangle, arrow, text, tag, blur brush, or AI segment tools
 3. **Esc** — Copies annotated screenshot to clipboard
 4. **Cmd+S** — Saves to disk + AI organizes in background

--- a/docs/USER_FLOWS.md
+++ b/docs/USER_FLOWS.md
@@ -69,9 +69,9 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 | Step | Action | Expected Result |
 |------|--------|-----------------|
 | 1 | Press Cmd+Shift+2 | Home window hides |
-| 2 | -- | Screen is captured via `desktopCapturer.getSources()` |
-| 3 | -- | Fullscreen transparent overlay appears on current viewport |
-| 4 | -- | Overlay covers entire screen including menu bar |
+| 2 | -- | Display under the cursor is captured via `desktopCapturer.getSources()` |
+| 3 | -- | Fullscreen transparent overlay appears on that display |
+| 4 | -- | Overlay covers entire display including menu bar |
 | 5 | -- | Cursor becomes crosshair, hint text visible: "Drag to select a region, then press Enter" |
 | 6 | Drag to select a rectangular region | Selection box appears with handles |
 | 7 | (Optional) Drag inside selection to reposition | Selection moves without resizing |

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -37,14 +37,15 @@ function createOverlayWindow() {
     overlayWindow = null;
   }
 
-  const primaryDisplay = screen.getPrimaryDisplay();
-  const { width, height } = primaryDisplay.size;
+  const cursorDisplay = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const { width, height } = cursorDisplay.size;
+  const { x, y } = cursorDisplay.bounds;
 
   overlayWindow = new BrowserWindow({
     width,
     height,
-    x: 0,
-    y: 0,
+    x,
+    y,
     frame: false,
     transparent: true,
     alwaysOnTop: true,

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -4,10 +4,12 @@
   'use strict';
 
   let capturedDataURL = null;
+  let displayOrigin = { x: 0, y: 0 };
   let selectionInstance = null;
 
   window.snip.onScreenshotCaptured(async (data) => {
     capturedDataURL = data.dataURL;
+    displayOrigin = data.displayOrigin || { x: 0, y: 0 };
     const width = window.innerWidth;
     const height = window.innerHeight;
 
@@ -58,9 +60,9 @@
         const scaleX = imgW / window.screen.width;
         const scaleY = imgH / window.screen.height;
 
-        // Account for overlay window's screen offset (menu bar / notch on macOS)
-        const winOffsetX = window.screenX || 0;
-        const winOffsetY = window.screenY || 0;
+        // Account for overlay window's offset within its display (menu bar / notch on macOS)
+        const winOffsetX = (window.screenX || 0) - displayOrigin.x;
+        const winOffsetY = (window.screenY || 0) - displayOrigin.y;
 
         const physX = Math.round((region.x + winOffsetX) * scaleX);
         const physY = Math.round((region.y + winOffsetY) * scaleY);


### PR DESCRIPTION
Instead of always capturing the primary display, detect the display under the cursor at capture time and target that display for both the screenshot source and the overlay window positioning.