### PR TITLE
Fix notarization: dynamic model pull, dedicated Ollama port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ vendor/models/
 
 # Lint cache
 .eslintcache
+
+# Personal
+personal/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,7 @@ These are non-negotiable rules. Violating them causes crashes or broken UX:
 | AI agent | `src/main/organizer/agent.js` + `worker.js` |
 | Ollama manager | `src/main/ollama-manager.js` |
 | Ollama binary (bundled) | `vendor/ollama/ollama` (dev) / `Resources/ollama/ollama` (packaged) |
-| Ollama models (bundled) | `vendor/ollama/models/` (dev) / `Resources/ollama/models/` (packaged) |
-| Ollama models (runtime) | `~/Library/Application Support/snip/ollama/models/` |
+| Ollama models (runtime) | `~/Library/Application Support/snip/ollama/models/` (pulled on first launch or symlinked from `~/.ollama/models/`) |
 | Config | `~/Library/Application Support/snip/snip-config.json` |
 | Screenshots | `~/Documents/snip/screenshots/` |
 | Index | `~/Documents/snip/screenshots/.index.json` |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -59,7 +59,7 @@ Power users on macOS who take 5-50 screenshots per day: developers, designers, P
 - File renamed and moved to category subfolder
 - 384-dim embedding generated for semantic search (HuggingFace Transformers.js, also local)
 - New category suggestions via macOS notification
-- Default model: `minicpm-v` (8B, Metal-accelerated on Apple Silicon)
+- Default model: `minicpm-v` (8B, Metal-accelerated on Apple Silicon) — pulled on first launch, not bundled. If user already has minicpm-v in system Ollama, blobs are symlinked (no re-download).
 
 ### Animation (2GIF)
 - Requires internet connection and a fal.ai API key (configured in Settings > Animation)
@@ -110,7 +110,7 @@ Power users on macOS who take 5-50 screenshots per day: developers, designers, P
 ## Product Principles
 
 1. **Clipboard-first**: Most users want the screenshot on their clipboard immediately. Saving to disk is secondary.
-2. **Zero-config by default**: Ollama binary and model auto-download on first launch. No onboarding wizard.
+2. **Zero-config by default**: Ollama binary bundled, model auto-pulled on first launch (or symlinked from system Ollama). No onboarding wizard.
 3. **Non-intrusive**: Tray-only, no Dock icon, no Space switching, hides during capture.
 4. **AI is invisible labor**: Users don't "invoke AI" — it just happens in the background after save.
 5. **Purple, always purple**: The brand color is violet/purple. Never blue. See [`DESIGN.md`](DESIGN.md).

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -53,12 +53,17 @@ asarUnpack:
   - "node_modules/upng-js/**"
   - "node_modules/pako/**"
   - "node_modules/ffmpeg-static/**"
+  - "node_modules/electron-liquid-glass/**"
 
 extraResources:
   - from: "build/Release/window_utils.node"
     to: "native/window_utils.node"
   - from: "vendor/ollama"
     to: "ollama"
+    filter:
+      - "**/*"
+      - "!models"
+      - "!models/**"
   - from: "vendor/models"
     to: "models"
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "ELECTRON_ENABLE_LOGGING=1 electron .",
     "postinstall": "electron-builder install-app-deps && npm run download-all",
     "prebuild": "node-gyp rebuild",
-    "build": "node-gyp rebuild && electron-builder --mac && npm run sign:adhoc",
+    "build": "node-gyp rebuild && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac && npm run sign:adhoc",
     "sign:adhoc": "for app in dist/mac-*/Snip.app; do if codesign -v \"$app\" 2>/dev/null; then echo \"Already signed: $app\"; else codesign --force --deep --sign - \"$app\" 2>/dev/null && echo \"Ad-hoc signed: $app\"; fi; done",
     "rebuild": "electron-rebuild",
     "download-ollama": "./scripts/download-ollama.sh",

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -102,6 +102,23 @@ module.exports = async function afterPack(context) {
   }
 
   // ---------------------------------------------------------------
+  // 2b. Remove wrong-arch electron-liquid-glass prebuilds
+  // ---------------------------------------------------------------
+  var elgPrebuildsDir = path.join(nmDir, 'electron-liquid-glass', 'prebuilds');
+  if (fs.existsSync(elgPrebuildsDir)) {
+    var elgPlatforms = fs.readdirSync(elgPrebuildsDir);
+    for (var ep = 0; ep < elgPlatforms.length; ep++) {
+      var elgPlat = elgPlatforms[ep];
+      if (elgPlat !== 'darwin-' + targetArch) {
+        removeDir(
+          path.join(elgPrebuildsDir, elgPlat),
+          'electron-liquid-glass ' + elgPlat + ' (building for ' + targetArch + ')'
+        );
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------
   // 4. Pre-sign remaining native binaries
   //    electron-builder will sign the whole app bundle after this
   //    hook, but third-party .dylib/.node files sometimes need to

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -107,6 +107,10 @@ function registerIpcHandlers(getOverlayWindow, createEditorWindowFn) {
     return ollamaManager.getStatus();
   });
 
+  ipcMain.handle('get-ollama-pull-progress', async () => {
+    return ollamaManager.getPullProgress();
+  });
+
   // Settings: Animation (fal.ai)
   ipcMain.handle('get-animation-config', async () => {
     return { falApiKey: getFalApiKey() };

--- a/src/main/ollama-manager.js
+++ b/src/main/ollama-manager.js
@@ -1,13 +1,15 @@
 /**
  * Ollama lifecycle manager.
  *
- * Spawns the bundled Ollama binary directly (no electron-ollama).
+ * Spawns the bundled Ollama binary on a dedicated port (default 11435)
+ * so it never conflicts with the user's own Ollama on 11434.
  * Binary lives in vendor/ollama/ (dev) or Resources/ollama/ (packaged).
- * Model files are copied to a writable user data directory on first launch.
+ * Models are pulled on first launch via `client.pull()` with progress tracking.
  */
 
 const path = require('path');
 const fs = require('fs');
+const net = require('net');
 const { spawn } = require('child_process');
 const { Ollama } = require('ollama');
 
@@ -17,6 +19,11 @@ let ollamaProcess = null;  // child process
 let client = null;          // Ollama JS client
 let serverRunning = false;
 let startupError = null;
+
+// Model pull state
+let pullInProgress = false;
+let pullProgress = { status: 'idle', percent: 0, total: 0, completed: 0 };
+let modelReady = false;
 
 /**
  * Resolve path to the bundled Ollama binary.
@@ -32,19 +39,6 @@ function getBinaryPath() {
 }
 
 /**
- * Resolve path to the bundled model files (read-only source).
- * - Production: process.resourcesPath/ollama/models
- * - Development: <project>/vendor/ollama/models
- */
-function getBundledModelsPath() {
-  var isPackaged = require('electron').app.isPackaged;
-  if (isPackaged) {
-    return path.join(process.resourcesPath, 'ollama', 'models');
-  }
-  return path.join(__dirname, '..', '..', 'vendor', 'ollama', 'models');
-}
-
-/**
  * Writable models directory in user data.
  * ~/Library/Application Support/snip/ollama/models/
  */
@@ -54,47 +48,34 @@ function getUserModelsPath() {
 }
 
 /**
- * Recursively copy a directory.
+ * Find an available port starting from preferredPort.
+ * Tries up to maxAttempts sequential ports.
  */
-function copyDirSync(src, dest) {
-  fs.mkdirSync(dest, { recursive: true });
-  var entries = fs.readdirSync(src, { withFileTypes: true });
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i];
-    var srcPath = path.join(src, entry.name);
-    var destPath = path.join(dest, entry.name);
-    if (entry.isDirectory()) {
-      copyDirSync(srcPath, destPath);
-    } else {
-      fs.copyFileSync(srcPath, destPath);
-    }
-  }
-}
+function findAvailablePort(preferredPort, maxAttempts) {
+  maxAttempts = maxAttempts || 10;
+  var attempt = 0;
 
-/**
- * Copy bundled model files to writable user data dir if not already present.
- */
-function ensureModels() {
-  var userModels = getUserModelsPath();
-  var bundledModels = getBundledModelsPath();
-  var defaultModel = getOllamaModel();
-
-  // Check if the default model manifest already exists in user dir
-  var manifestDir = path.join(userModels, 'manifests', 'registry.ollama.ai', 'library', defaultModel);
-  if (fs.existsSync(manifestDir)) {
-    console.log('[Ollama] Model "%s" already in user data', defaultModel);
-    return;
+  function tryPort(port) {
+    return new Promise(function (resolve, reject) {
+      var server = net.createServer();
+      server.unref();
+      server.on('error', function () {
+        if (attempt < maxAttempts - 1) {
+          attempt++;
+          resolve(tryPort(port + 1));
+        } else {
+          reject(new Error('No available port found in range ' + preferredPort + '-' + (preferredPort + maxAttempts - 1)));
+        }
+      });
+      server.listen(port, '127.0.0.1', function () {
+        server.close(function () {
+          resolve(port);
+        });
+      });
+    });
   }
 
-  // Check if bundled models exist
-  if (!fs.existsSync(bundledModels)) {
-    console.log('[Ollama] No bundled models found at %s', bundledModels);
-    return;
-  }
-
-  console.log('[Ollama] Copying bundled model files to %s ...', userModels);
-  copyDirSync(bundledModels, userModels);
-  console.log('[Ollama] Model files copied');
+  return tryPort(preferredPort);
 }
 
 /**
@@ -124,8 +105,183 @@ function waitForServer(url, timeoutMs) {
 }
 
 /**
- * Start the embedded Ollama server.
- * Copies bundled models on first launch, then spawns `ollama serve`.
+ * Send pull progress to all open BrowserWindows.
+ */
+function emitPullProgress(progress) {
+  var { BrowserWindow } = require('electron');
+  var wins = BrowserWindow.getAllWindows();
+  for (var i = 0; i < wins.length; i++) {
+    if (!wins[i].isDestroyed()) {
+      try {
+        wins[i].webContents.send('ollama-pull-progress', progress);
+      } catch (_) { /* ignore destroyed windows */ }
+    }
+  }
+}
+
+/**
+ * Try to symlink a model from the user's system Ollama (~/.ollama/models/)
+ * into Snip's model directory to avoid re-downloading.
+ * Returns true if symlink was successful, false otherwise.
+ */
+function trySymlinkSystemModel(modelName) {
+  var os = require('os');
+  var systemModelsDir = path.join(os.homedir(), '.ollama', 'models');
+  var snipModelsDir = getUserModelsPath();
+
+  // Check if system Ollama has the model manifest
+  var systemManifestDir = path.join(systemModelsDir, 'manifests', 'registry.ollama.ai', 'library', modelName);
+  var systemManifestFile = path.join(systemManifestDir, 'latest');
+  if (!fs.existsSync(systemManifestFile)) {
+    return false;
+  }
+
+  try {
+    // Read the manifest to find which blobs are needed
+    var manifest = JSON.parse(fs.readFileSync(systemManifestFile, 'utf8'));
+    var blobDigests = [];
+
+    // Collect all blob digests from the manifest (config + layers)
+    if (manifest.config && manifest.config.digest) {
+      blobDigests.push(manifest.config.digest);
+    }
+    if (manifest.layers) {
+      for (var i = 0; i < manifest.layers.length; i++) {
+        if (manifest.layers[i].digest) {
+          blobDigests.push(manifest.layers[i].digest);
+        }
+      }
+    }
+
+    // Verify all blobs exist in system Ollama
+    var systemBlobsDir = path.join(systemModelsDir, 'blobs');
+    for (var b = 0; b < blobDigests.length; b++) {
+      var blobFile = path.join(systemBlobsDir, blobDigests[b].replace(':', '-'));
+      if (!fs.existsSync(blobFile)) {
+        console.log('[Ollama] System blob missing: %s — cannot symlink', blobDigests[b]);
+        return false;
+      }
+    }
+
+    // All blobs exist — create symlinks
+    var snipBlobsDir = path.join(snipModelsDir, 'blobs');
+    fs.mkdirSync(snipBlobsDir, { recursive: true });
+
+    var linkedCount = 0;
+    for (var s = 0; s < blobDigests.length; s++) {
+      var digest = blobDigests[s];
+      var srcBlob = path.join(systemBlobsDir, digest.replace(':', '-'));
+      var destBlob = path.join(snipBlobsDir, digest.replace(':', '-'));
+
+      if (!fs.existsSync(destBlob)) {
+        fs.symlinkSync(srcBlob, destBlob);
+        linkedCount++;
+      }
+    }
+
+    // Copy the manifest (small file, not worth symlinking)
+    var snipManifestDir = path.join(snipModelsDir, 'manifests', 'registry.ollama.ai', 'library', modelName);
+    fs.mkdirSync(snipManifestDir, { recursive: true });
+    var snipManifestFile = path.join(snipManifestDir, 'latest');
+    if (!fs.existsSync(snipManifestFile)) {
+      fs.copyFileSync(systemManifestFile, snipManifestFile);
+    }
+
+    console.log('[Ollama] Symlinked %d blobs from system Ollama for model "%s"', linkedCount, modelName);
+    return true;
+  } catch (err) {
+    console.warn('[Ollama] Failed to symlink system model:', err.message);
+    return false;
+  }
+}
+
+/**
+ * Ensure the required model is available, pulling it if needed.
+ * Checks: 1) Snip's own store, 2) system Ollama (symlink), 3) pull from registry.
+ * Called after the Ollama server is running. Non-blocking to callers.
+ */
+async function ensureModel() {
+  var defaultModel = getOllamaModel();
+
+  // Check if model already exists in Snip's store
+  try {
+    var models = await client.list();
+    var found = (models.models || []).some(function (m) {
+      return m.name === defaultModel || m.name === defaultModel + ':latest';
+    });
+    if (found) {
+      console.log('[Ollama] Model "%s" already available', defaultModel);
+      modelReady = true;
+      pullProgress = { status: 'ready', percent: 100, total: 0, completed: 0 };
+      emitPullProgress(pullProgress);
+      return;
+    }
+  } catch (err) {
+    console.warn('[Ollama] Failed to list models:', err.message);
+  }
+
+  // Try to symlink from user's system Ollama (~/.ollama/models/)
+  if (trySymlinkSystemModel(defaultModel)) {
+    // Verify the symlinked model is now visible to our server
+    try {
+      var modelsAfterLink = await client.list();
+      var linkedFound = (modelsAfterLink.models || []).some(function (m) {
+        return m.name === defaultModel || m.name === defaultModel + ':latest';
+      });
+      if (linkedFound) {
+        console.log('[Ollama] Model "%s" available via system Ollama symlink', defaultModel);
+        modelReady = true;
+        pullProgress = { status: 'ready', percent: 100, total: 0, completed: 0 };
+        emitPullProgress(pullProgress);
+        return;
+      }
+    } catch (err) {
+      console.warn('[Ollama] Symlink verification failed:', err.message);
+    }
+  }
+
+  // Model not found anywhere — pull from registry
+  console.log('[Ollama] Model "%s" not found locally — pulling...', defaultModel);
+  pullInProgress = true;
+  pullProgress = { status: 'downloading', percent: 0, total: 0, completed: 0 };
+  emitPullProgress(pullProgress);
+
+  try {
+    var stream = await client.pull({ model: defaultModel, stream: true });
+    for await (var event of stream) {
+      if (event.total && event.total > 0) {
+        pullProgress = {
+          status: event.status || 'downloading',
+          percent: Math.round((event.completed / event.total) * 100),
+          total: event.total,
+          completed: event.completed
+        };
+      } else {
+        pullProgress = {
+          status: event.status || 'downloading',
+          percent: pullProgress.percent,
+          total: pullProgress.total,
+          completed: pullProgress.completed
+        };
+      }
+      emitPullProgress(pullProgress);
+    }
+    console.log('[Ollama] Model "%s" pulled successfully', defaultModel);
+    modelReady = true;
+    pullInProgress = false;
+    pullProgress = { status: 'ready', percent: 100, total: 0, completed: 0 };
+    emitPullProgress(pullProgress);
+  } catch (err) {
+    console.error('[Ollama] Pull failed:', err.message);
+    pullInProgress = false;
+    pullProgress = { status: 'error', percent: 0, total: 0, completed: 0, error: err.message };
+    emitPullProgress(pullProgress);
+  }
+}
+
+/**
+ * Start the embedded Ollama server on a dedicated port.
+ * Pulls the model on first launch instead of bundling it.
  */
 async function startOllama() {
   var binaryPath = getBinaryPath();
@@ -137,19 +293,24 @@ async function startOllama() {
   }
 
   try {
-    // Copy bundled models to writable location if needed
-    ensureModels();
-
     var modelsPath = getUserModelsPath();
     fs.mkdirSync(modelsPath, { recursive: true });
 
-    var host = getOllamaUrl() || 'http://127.0.0.1:11434';
+    // Parse preferred host/port from config
+    var configUrl = getOllamaUrl() || 'http://127.0.0.1:11435';
+    var urlObj = new URL(configUrl);
+    var preferredPort = parseInt(urlObj.port, 10) || 11435;
 
-    // Spawn ollama serve
-    console.log('[Ollama] Starting server from %s', binaryPath);
+    // Find an available port starting from the preferred one
+    var port = await findAvailablePort(preferredPort);
+    var host = 'http://127.0.0.1:' + port;
+
+    console.log('[Ollama] Starting server from %s on port %d', binaryPath, port);
+
+    // Spawn ollama serve on the dedicated port
     ollamaProcess = spawn(binaryPath, ['serve'], {
       env: Object.assign({}, process.env, {
-        OLLAMA_HOST: host.replace(/^https?:\/\//, ''),
+        OLLAMA_HOST: '127.0.0.1:' + port,
         OLLAMA_MODELS: modelsPath
       }),
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -177,10 +338,15 @@ async function startOllama() {
 
     serverRunning = true;
     startupError = null;
-    console.log('[Ollama] Server started');
+    console.log('[Ollama] Server started on %s', host);
 
-    // Create JS client
+    // Create JS client pointing to our dedicated server
     client = new Ollama({ host: host });
+
+    // Ensure the model is available (non-blocking — runs in background)
+    ensureModel().catch(function (err) {
+      console.error('[Ollama] ensureModel failed:', err.message);
+    });
   } catch (err) {
     startupError = err.message;
     console.error('[Ollama] Failed to start:', err.message);
@@ -202,13 +368,14 @@ async function stopOllama() {
   serverRunning = false;
   client = null;
   ollamaProcess = null;
+  modelReady = false;
 }
 
 /**
- * Check if the Ollama server is running and reachable.
+ * Check if the Ollama server is running, reachable, and the model is ready.
  */
 async function isReady() {
-  if (!client) return false;
+  if (!client || !modelReady) return false;
   try {
     await client.list();
     return true;
@@ -232,10 +399,17 @@ async function listModels() {
 }
 
 /**
+ * Get current pull progress for IPC.
+ */
+function getPullProgress() {
+  return pullProgress;
+}
+
+/**
  * Get current Ollama status for the settings UI.
  */
 async function getStatus() {
-  var running = await isReady();
+  var running = serverRunning;
   var models = await listModels();
   return {
     running: running,
@@ -247,7 +421,10 @@ async function getStatus() {
         modified: m.modified_at
       };
     }),
-    currentModel: getOllamaModel()
+    currentModel: getOllamaModel(),
+    modelReady: modelReady,
+    pulling: pullInProgress,
+    pullProgress: pullProgress
   };
 }
 
@@ -255,5 +432,6 @@ module.exports = {
   startOllama,
   stopOllama,
   isReady,
-  getStatus
+  getStatus,
+  getPullProgress
 };

--- a/src/main/store.js
+++ b/src/main/store.js
@@ -86,7 +86,7 @@ function setOllamaModel(model) {
 }
 
 function getOllamaUrl() {
-  return loadConfig().ollamaUrl || 'http://127.0.0.1:11434';
+  return loadConfig().ollamaUrl || 'http://127.0.0.1:11435';
 }
 
 function setOllamaUrl(url) {

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -19,6 +19,12 @@ contextBridge.exposeInMainWorld('snip', {
   getOllamaConfig: () => ipcRenderer.invoke('get-ollama-config'),
   setOllamaConfig: (config) => ipcRenderer.invoke('set-ollama-config', config),
   getOllamaStatus: () => ipcRenderer.invoke('get-ollama-status'),
+  getOllamaPullProgress: () => ipcRenderer.invoke('get-ollama-pull-progress'),
+  onOllamaPullProgress: (callback) => {
+    var handler = (event, progress) => callback(progress);
+    ipcRenderer.on('ollama-pull-progress', handler);
+    return () => ipcRenderer.removeListener('ollama-pull-progress', handler);
+  },
   getCategories: () => ipcRenderer.invoke('get-categories'),
   addCategory: (category) => ipcRenderer.invoke('add-category', category),
   removeCategory: (category) => ipcRenderer.invoke('remove-category', category),

--- a/src/renderer/home.css
+++ b/src/renderer/home.css
@@ -727,6 +727,46 @@ input:focus { border-color: var(--accent); }
   word-break: break-all;
 }
 
+/* Model download progress */
+.model-download-section {
+  margin-bottom: 12px;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-card);
+  border-radius: 10px;
+}
+
+.model-download-section.hidden { display: none; }
+
+.model-download-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.model-download-bar-track {
+  width: 100%;
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+
+.model-download-bar-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.model-download-detail {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
 /* Current model card */
 .current-model-card {
   background: var(--bg-elevated);

--- a/src/renderer/home.html
+++ b/src/renderer/home.html
@@ -176,6 +176,13 @@
             <span id="ollama-status-dot" class="status-dot"></span>
             <span id="ollama-status-text">Checking...</span>
           </div>
+          <div id="model-download-section" class="model-download-section hidden">
+            <div class="model-download-label">Downloading AI model...</div>
+            <div class="model-download-bar-track">
+              <div id="model-download-bar" class="model-download-bar-fill"></div>
+            </div>
+            <div id="model-download-detail" class="model-download-detail">Preparing...</div>
+          </div>
           <div class="current-model-card">
             <span class="current-model-label">Active Model</span>
             <div class="current-model-header">


### PR DESCRIPTION
## Summary

Fixes #4 — App notarization was failing because the bundled minicpm-v model (~5 GB) made the app ~6.1 GB, causing notarization uploads to time out or get stuck "In Progress" indefinitely.

### Approach

- **Ollama binary + support libraries are still bundled** (~220 MB) — no change there
- **minicpm-v model is no longer bundled** — it is pulled dynamically on first launch via `client.pull()`, reducing the app from ~6.1 GB to ~0.8 GB
- **Dedicated Ollama port (11435)** — Snip spawns its own Ollama server on port 11435 instead of 11434, so it never conflicts with the user's own Ollama installation
- **Auto port discovery** — if 11435 is taken, tries 11436–11445 automatically via `findAvailablePort()`
- **System model symlink** — if the user already has minicpm-v in their system Ollama (`~/.ollama/models/`), blobs are symlinked instead of re-downloaded (~5 GB saved)
- **Download progress UI** — Settings page shows a progress bar with percentage + MB downloaded while the model is being pulled
- **afterPack.js fixes** — removes wrong-arch `electron-liquid-glass` prebuilds and pre-signs the Ollama binary + all native libraries (`.dylib`, `.so`, `.metallib`) for notarization
- **Ad-hoc build fix** — `npm run build` now sets `CSC_IDENTITY_AUTO_DISCOVERY=false` so it doesn't accidentally sign with Developer ID during test builds

### Files Changed

| File | Change |
|------|--------|
| `electron-builder.yml` | Exclude `models/` from ollama extraResources; add `electron-liquid-glass` to asarUnpack |
| `src/main/ollama-manager.js` | Rewrite: dedicated port, auto port finding, `ensureModel()` with pull + symlink, progress tracking |
| `src/main/store.js` | Default Ollama URL port 11434 → 11435 |
| `src/main/ipc-handlers.js` | Add `get-ollama-pull-progress` IPC handler |
| `src/preload/preload.js` | Add `getOllamaPullProgress` and `onOllamaPullProgress` bridge |
| `src/renderer/home.html` | Add model download progress bar section |
| `src/renderer/home.css` | Progress bar styles |
| `src/renderer/home.js` | Wire up progress display, handle new status states |
| `scripts/afterPack.js` | Add electron-liquid-glass wrong-arch cleanup; sign Ollama binary + libs |
| `package.json` | Disable CSC auto-discovery in `npm run build` |
| `docs/*` | Updated ARCHITECTURE, DEVOPS, USER_FLOWS, PRODUCT docs |

## Test plan

- [ ] `npm run build` produces an ad-hoc signed app (~0.8 GB, no Developer ID signing)
- [ ] `npm run dev` starts Ollama on port 11435 (check `curl http://127.0.0.1:11435`)
- [ ] User's own Ollama on port 11434 is unaffected
- [ ] First launch without minicpm-v shows download progress bar in Settings
- [ ] If user has minicpm-v in `~/.ollama/models/`, model is symlinked (no download)
- [ ] After model ready, AI organization works (save screenshot → gets categorized)
- [ ] `./scripts/build-signed.sh` produces signed + notarized DMG
- [ ] `codesign --verify --deep --strict dist/mac-arm64/Snip.app` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)