### PR TITLE
Add AI choice screen to onboarding flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This project is **fully autonomous**. Claude Code operates independently across 
 | Build / scripts / native modules | `docs/DEVOPS.md` scripts table + build pipeline |
 | Code conventions changed | `docs/ARCHITECTURE.md` conventions section |
 | New tool or annotation type | `docs/PRODUCT.md` tool table + `docs/USER_FLOWS.md` new tool flow + `docs/ARCHITECTURE.md` directory tree + `README.md` shortcut table |
-| Theme system changes | `docs/DESIGN.md` + `docs/ARCHITECTURE.md` theme system section + `docs/USER_FLOWS.md` §8.3 |
+| Theme system changes | `docs/DESIGN.md` + `docs/ARCHITECTURE.md` theme system section + `docs/USER_FLOWS.md` §8.4 |
 
 ### How to Update
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ src/
     ipc-handlers.js          # All IPC channel handlers
     tray.js                  # Menu-bar tray icon and context menu
     shortcuts.js             # Global keyboard shortcuts (Cmd+Shift+2, Cmd+Shift+F)
-    store.js                 # Config persistence, index I/O, fal.ai API key storage, reloadConfig()
+    store.js                 # Config persistence, index I/O, fal.ai API key storage, aiEnabled flag, reloadConfig()
     constants.js             # Shared constants (BASE_WEB_PREFERENCES)
     ollama-manager.js        # Ollama process lifecycle (spawn/kill on dynamic port, ready/status/model pull)
     model-paths.js           # Bundled model path resolution (dev vs packaged)
@@ -225,6 +225,7 @@ The preload script (`preload.js`) exposes `window.snip` with these methods:
 
 | Method | Direction | Purpose |
 |--------|-----------|---------|
+| `getAiEnabled()` / `setAiEnabled(val)` | R -> M | AI opt-in flag (`true`, `false`, or `undefined` on first launch) |
 | `getOllamaConfig()` / `setOllamaConfig(cfg)` | R -> M | Ollama model/URL settings |
 | `getOllamaStatus()` | R -> M | Server running? Model ready? Pull progress? |
 | `getOllamaPullProgress()` | R -> M | Current model download progress |
@@ -327,6 +328,13 @@ The native Liquid Glass layer is always present (macOS 26+). Dark and Light them
 | Animations | `~/Documents/snip/screenshots/animations/` | same |
 | Index | `~/Documents/snip/screenshots/.index.json` | same |
 | Config | `~/Library/Application Support/snip/snip-config.json` | same |
+
+**Config fields of note:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `aiEnabled` | `boolean \| undefined` | `undefined` on first launch (triggers AI choice screen), `true` if user opted in, `false` if user opted out. When `false`, Ollama is not started and AI organization is skipped entirely. |
+
 | Ollama binary | `/usr/local/bin/ollama`, `/opt/homebrew/bin/ollama`, or `/Applications/Ollama.app/Contents/Resources/ollama` | same (user-installed) |
 | Ollama models | `~/.ollama/models/` | same (shared with system Ollama) |
 | HF models (MiniLM + SlimSAM) | `vendor/models/` | `Resources/models/` |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -114,9 +114,10 @@ Power users on macOS who take 5-50 screenshots per day: developers, designers, P
 
 1. **Clipboard-first**: Most users want the screenshot on their clipboard immediately. Saving to disk is secondary.
 2. **Zero-config by default**: In-app setup wizard guides Ollama install and model download on first launch. Works without AI if user skips setup.
-3. **Non-intrusive**: Tray-only, no Dock icon, no Space switching, hides during capture.
-4. **AI is invisible labor**: Users don't "invoke AI" — it just happens in the background after save.
-5. **Purple, always purple**: The brand color is violet/purple. Never blue. See [`DESIGN.md`](DESIGN.md).
+3. **AI is optional**: Users choose during onboarding whether to enable AI. The app works fully without it — capture, annotate, save, and browse all function normally. Only smart naming, tagging, and organization require AI. Users who opted out can enable AI later from Settings.
+4. **Non-intrusive**: Tray-only, no Dock icon, no Space switching, hides during capture.
+5. **AI is invisible labor**: Users don't "invoke AI" — it just happens in the background after save.
+6. **Purple, always purple**: The brand color is violet/purple. Never blue. See [`DESIGN.md`](DESIGN.md).
 
 ---
 

--- a/docs/USER_FLOWS.md
+++ b/docs/USER_FLOWS.md
@@ -604,15 +604,54 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 
 ## 8. Settings
 
-### 8.1 Setting Up Your AI Assistant (Inline Overlay)
+### 8.1 AI Choice Screen
 
-The setup wizard appears as a **full-window inline overlay** inside the home window (not a separate popup). It auto-shows on first launch if Ollama is not fully ready, and can be reopened from the Settings "Set up" button.
+On first launch, the app presents an AI choice screen before any Ollama setup. The user's decision is persisted as `aiEnabled` in the config file.
 
-**Overlay structure:** Three views — Steps (install/running/model), Welcome, Failed. Only one visible at a time. Step cards show numbered indicators (pending → active → done with checkmark).
+**First Launch (aiEnabled = undefined):**
 
 | Step | Action | Expected Result |
 |------|--------|-----------------|
-| 1 | App launches without Ollama ready | Inline overlay covers home window with step-by-step wizard |
+| 1 | App launches, `aiEnabled` not set in config | main.js starts Ollama detection (may find it not installed) |
+| 2 | -- | Overlay shows AI choice view first, with title **"Smart Organization"** |
+| 3 | -- | Description: "Snip can use a local AI to automatically name, tag, and organize your snips. Everything runs on your machine." |
+| 4 | -- | Two buttons: **"Set up AI"** and **"Continue without AI"** |
+| 5a | Click "Set up AI" | `aiEnabled` set to `true` in config; proceeds to install/running/model setup steps (see 8.2) |
+| 5b | Click "Continue without AI" | `aiEnabled` set to `false` in config; overlay dismissed; app works without AI |
+
+**Subsequent Launch (aiEnabled = true):**
+
+| Condition | Expected Behavior |
+|-----------|-------------------|
+| Ollama fully ready | Normal startup, no overlay |
+| Ollama not fully ready | Setup overlay shows install/running/model steps (see 8.2), skips AI choice screen |
+
+**Subsequent Launch (aiEnabled = false):**
+
+| Condition | Expected Behavior |
+|-----------|-------------------|
+| App starts | Ollama skipped entirely — no spawn, no health check |
+| -- | No setup overlay shown |
+| -- | Screenshots indexed with basic metadata only (filename, `category: 'other'`, no AI naming/tagging) |
+| -- | AI assistant section hidden in Settings page |
+
+**Settings "Set up" button (when aiEnabled = false):**
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | User navigates to Settings, clicks "Set up" | Goes straight to steps view (skips AI choice screen) |
+| 2 | -- | `aiEnabled` set to `true` |
+| 3 | -- | Ollama install/running/model flow proceeds normally |
+
+### 8.2 Setting Up Your AI Assistant (Inline Overlay)
+
+The setup wizard appears as a **full-window inline overlay** inside the home window (not a separate popup). It auto-shows on first launch if the user chose "Set up AI" (aiEnabled = true) and Ollama is not fully ready, and can be reopened from the Settings "Set up" button.
+
+**Overlay structure:** Four views — AI Choice (first launch only), Steps (install/running/model), Welcome, Failed. Only one visible at a time. Step cards show numbered indicators (pending -> active -> done with checkmark).
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | App launches without Ollama ready (and aiEnabled = true) | Inline overlay covers home window with step-by-step wizard |
 | 2 | -- | App auto-detects current state and shows appropriate step |
 
 **Step: Install Ollama**
@@ -674,7 +713,7 @@ The setup wizard appears as a **full-window inline overlay** inside the home win
 | "Continue in background" | Shown when download is active, dismisses overlay |
 | App works without Ollama | Capture/annotate work normally, no AI organization |
 
-### 8.3 Theme Toggle
+### 8.4 Theme Toggle
 
 | Step | Action | Expected Result |
 |------|--------|-----------------|
@@ -686,7 +725,7 @@ The setup wizard appears as a **full-window inline overlay** inside the home win
 | 6 | -- | CSS `backdrop-filter` disabled (native layer handles blur) |
 | 7 | Select Dark or Light theme | Standard opaque backgrounds restored, glass layer hidden |
 
-### 8.4 Category Management
+### 8.5 Category Management
 
 | Step | Action | Expected Result |
 |------|--------|-----------------|
@@ -698,7 +737,7 @@ The setup wizard appears as a **full-window inline overlay** inside the home win
 | 6 | Click remove (X) on a custom tag | Tag removed from config |
 | 7 | -- | Built-in tags cannot be removed |
 
-### 8.5 Keyboard Shortcuts Reference
+### 8.6 Keyboard Shortcuts Reference
 
 | Step | Action | Expected Result |
 |------|--------|-----------------|

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -7,6 +7,7 @@ const {
   getAllTagsWithDescriptions, setTagDescription, addCustomCategoryWithDescription,
   readIndex, removeFromIndex, removeFromIndexByDir, rebuildIndex,
   getTheme, setTheme,
+  getAiEnabled, setAiEnabled,
   getFalApiKey, setFalApiKey
 } = require('./store');
 const { queueNewFile } = require('./organizer/watcher');
@@ -84,6 +85,27 @@ function registerIpcHandlers(getOverlayWindow, createEditorWindowFn) {
       'Courier New', 'Georgia', 'Times New Roman', 'Verdana',
       'Comic Sans MS', 'Impact', 'Futura', 'Avenir'
     ];
+  });
+
+  // AI preference
+  ipcMain.handle('get-ai-enabled', async () => {
+    return getAiEnabled();
+  });
+
+  ipcMain.handle('set-ai-enabled', async (event, enabled) => {
+    setAiEnabled(enabled);
+    if (enabled) {
+      // User opted in — start Ollama immediately
+      const { startOllama } = require('./ollama-manager');
+      startOllama().catch(err => {
+        console.warn('[Snip] Ollama start after AI enable failed:', err.message);
+      });
+    } else {
+      // User opted out — stop Ollama to free resources
+      const { stopOllama } = require('./ollama-manager');
+      stopOllama();
+    }
+    return true;
   });
 
   // Settings: Ollama

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -264,20 +264,18 @@ app.whenReady().then(() => {
     sendToHomeWindow('show-setup-overlay');
   });
 
-  // Detect system Ollama and connect (no bundled binary)
-  startOllama().then(async function () {
-    var { checkModel, isReady } = require('./ollama-manager');
-    await checkModel();
-    // Show setup overlay if Ollama is not fully ready
-    var ready = await isReady();
-    if (!ready) {
-      sendToHomeWindow('show-setup-overlay');
-    }
-  }).catch(function (err) {
-    console.error('[Snip] Ollama startup failed:', err.message);
-    // Not installed or failed — show setup overlay
-    sendToHomeWindow('show-setup-overlay');
-  });
+  // Detect system Ollama and connect (no bundled binary) — skip if AI not explicitly enabled
+  var { getAiEnabled } = require('./store');
+  if (getAiEnabled() === true) {
+    startOllama().then(async function () {
+      var { checkModel } = require('./ollama-manager');
+      await checkModel();
+    }).catch(function (err) {
+      console.error('[Snip] Ollama startup failed:', err.message);
+    });
+  } else {
+    console.log('[Snip] AI disabled — skipping Ollama startup');
+  }
 
   // Pre-warm SAM segmentation model
   const { warmUp } = require('./segmentation/segmentation');

--- a/src/main/organizer/embeddings.js
+++ b/src/main/organizer/embeddings.js
@@ -49,47 +49,46 @@ async function searchScreenshots(query) {
 
   if (index.length === 0) return [];
 
-  // Check if any entries have embeddings
-  const hasEmbeddings = index.some(entry => entry.embedding);
+  // Split entries into embedded vs non-embedded
+  const withEmbeddings = index.filter(entry => entry.embedding);
+  const withoutEmbeddings = index.filter(entry => !entry.embedding);
 
-  if (hasEmbeddings) {
-    // Semantic search using embeddings
+  let semanticResults = [];
+  if (withEmbeddings.length > 0) {
     try {
       const queryEmbedding = await embedText(query);
       const queryArray = Array.from(queryEmbedding);
 
-      const scored = index
-        .filter(entry => entry.embedding)
+      semanticResults = withEmbeddings
         .map(entry => ({
           ...entry,
           score: cosineSimilarity(queryArray, entry.embedding)
-        }))
-        .sort((a, b) => b.score - a.score)
-        .slice(0, 20);
-
-      return scored;
+        }));
     } catch (err) {
       console.error('[Search] Embedding search failed, falling back to text:', err.message);
+      // Treat as non-embedded for text fallback
+      withoutEmbeddings.push(...withEmbeddings);
     }
   }
 
-  // Fallback: simple text matching
+  // Text matching for entries without embeddings
   const queryLower = query.toLowerCase();
   const words = queryLower.split(/\s+/);
 
-  const scored = index.map(entry => {
-    const searchable = `${entry.name || ''} ${entry.description || ''} ${(entry.tags || []).join(' ')} ${entry.category || ''}`.toLowerCase();
+  const textResults = withoutEmbeddings.map(entry => {
+    const searchable = `${entry.filename || ''} ${entry.name || ''} ${entry.description || ''} ${(entry.tags || []).join(' ')} ${entry.category || ''}`.toLowerCase();
     let score = 0;
     for (const word of words) {
       if (searchable.includes(word)) score += 1;
     }
-    return { ...entry, score: score / words.length };
-  })
-    .filter(entry => entry.score > 0)
+    return { ...entry, score: words.length > 0 ? score / words.length : 0 };
+  });
+
+  // Merge and sort by score
+  return semanticResults
+    .concat(textResults)
     .sort((a, b) => b.score - a.score)
     .slice(0, 20);
-
-  return scored;
 }
 
 module.exports = { embedText, searchScreenshots };

--- a/src/main/organizer/watcher.js
+++ b/src/main/organizer/watcher.js
@@ -49,6 +49,13 @@ function startWatcher() {
     var ext = path.extname(filepath).toLowerCase();
     if (!['.jpg', '.jpeg', '.png'].includes(ext)) return;
 
+    // Skip agent processing if AI is not explicitly enabled
+    var { getAiEnabled } = require('../store');
+    if (getAiEnabled() !== true) {
+      addBasicIndexEntry(filepath);
+      return;
+    }
+
     // Only run the agent on files saved by the app (not manual renames/copies)
     if (!pendingFiles.has(filepath)) {
       console.log('[Organizer] External file detected, indexing without agent:', path.basename(filepath));

--- a/src/main/store.js
+++ b/src/main/store.js
@@ -273,6 +273,16 @@ function setTheme(theme) {
   saveConfig();
 }
 
+function getAiEnabled() {
+  var val = loadConfig().aiEnabled;
+  return val === undefined ? undefined : !!val;
+}
+
+function setAiEnabled(enabled) {
+  loadConfig().aiEnabled = !!enabled;
+  saveConfig();
+}
+
 function getFalApiKey() {
   return loadConfig().falApiKey || '';
 }
@@ -305,6 +315,8 @@ module.exports = {
   rebuildIndex,
   getTheme,
   setTheme,
+  getAiEnabled,
+  setAiEnabled,
   getFalApiKey,
   setFalApiKey,
 };

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -15,6 +15,10 @@ contextBridge.exposeInMainWorld('snip', {
   getEditorImage: () => ipcRenderer.invoke('get-editor-image'),
   closeEditor: () => ipcRenderer.send('close-editor'),
 
+  // AI preference
+  getAiEnabled: () => ipcRenderer.invoke('get-ai-enabled'),
+  setAiEnabled: (enabled) => ipcRenderer.invoke('set-ai-enabled', enabled),
+
   // Settings: Ollama
   getOllamaConfig: () => ipcRenderer.invoke('get-ollama-config'),
   setOllamaConfig: (config) => ipcRenderer.invoke('set-ollama-config', config),
@@ -91,7 +95,7 @@ contextBridge.exposeInMainWorld('snip', {
   animateCutout: ({ cutoutDataURL, presetName, options }) =>
     ipcRenderer.invoke('animate-cutout', { cutoutDataURL, presetName, options }),
   onAnimateProgress: (callback) => {
-    const handler = (event, progress) => callback(progress);
+    var handler = (event, progress) => callback(progress);
     ipcRenderer.on('animate-progress', handler);
     return () => ipcRenderer.removeListener('animate-progress', handler);
   },

--- a/src/renderer/editor-styles.css
+++ b/src/renderer/editor-styles.css
@@ -462,9 +462,9 @@ select:hover {
 }
 
 .tutorial-modal {
-  max-width: 340px;
-  padding: 24px 28px;
-  border-radius: 14px;
+  max-width: 360px;
+  padding: 28px 32px;
+  border-radius: 16px;
   background: var(--bg-toast);
   backdrop-filter: blur(var(--glass-blur));
   -webkit-backdrop-filter: blur(var(--glass-blur));
@@ -473,11 +473,52 @@ select:hover {
   text-align: center;
 }
 
+.tutorial-header-icon {
+  margin-bottom: 12px;
+  opacity: 0.9;
+}
+
 .tutorial-title {
   font-size: 16px;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--text-primary);
-  margin-bottom: 12px;
+  margin-bottom: 16px;
+}
+
+.tutorial-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 22px;
+  text-align: left;
+}
+
+.tutorial-step {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.tutorial-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 24px;
+  padding: 0 8px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-card);
+  border-radius: 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tutorial-text {

--- a/src/renderer/editor.html
+++ b/src/renderer/editor.html
@@ -173,12 +173,30 @@
     <!-- Segment tutorial modal -->
     <div id="segment-tutorial-backdrop" class="tutorial-backdrop hidden">
       <div class="tutorial-modal">
+        <div class="tutorial-header-icon">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M17 3a2.85 2.85 0 114 4L7.5 20.5 2 22l1.5-5.5Z"/>
+            <path d="M15 5l4 4"/>
+          </svg>
+        </div>
         <div class="tutorial-title">Segment Tool</div>
-        <div class="tutorial-text">
-          <strong>Click</strong> on any object to automatically select it.<br>
-          <strong>Shift + Click</strong> to add more points and refine the selection.<br>
-          Then choose: <strong>Tag Segment (T)</strong> to highlight and label,<br>
-          or <strong>Apply Cutout (Enter)</strong> to isolate.
+        <div class="tutorial-steps">
+          <div class="tutorial-step">
+            <kbd class="tutorial-kbd">Click</kbd>
+            <span>Select any object automatically</span>
+          </div>
+          <div class="tutorial-step">
+            <kbd class="tutorial-kbd">Shift + Click</kbd>
+            <span>Add points to refine the selection</span>
+          </div>
+          <div class="tutorial-step">
+            <kbd class="tutorial-kbd">T</kbd>
+            <span>Tag segment with a label</span>
+          </div>
+          <div class="tutorial-step">
+            <kbd class="tutorial-kbd">Enter</kbd>
+            <span>Apply cutout to isolate</span>
+          </div>
         </div>
         <button id="segment-tutorial-dismiss" class="tutorial-dismiss-btn">Got it</button>
       </div>

--- a/src/renderer/home.css
+++ b/src/renderer/home.css
@@ -646,6 +646,63 @@ input:focus { border-color: var(--accent); }
   transform: scale(0.97);
 }
 
+/* AI on/off toggle */
+.ai-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0 12px;
+}
+
+.ai-toggle-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.ai-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  cursor: pointer;
+}
+
+.ai-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.ai-switch-track {
+  position: absolute;
+  inset: 0;
+  background: var(--bg-tertiary);
+  border-radius: 20px;
+  transition: background 0.2s ease;
+}
+
+.ai-switch-track::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--text-muted);
+  border-radius: 50%;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.ai-switch input:checked + .ai-switch-track {
+  background: var(--accent);
+}
+
+.ai-switch input:checked + .ai-switch-track::after {
+  transform: translateX(16px);
+  background: #fff;
+}
+
 /* Ollama settings */
 .ollama-status-row {
   display: flex;
@@ -748,7 +805,8 @@ input:focus { border-color: var(--accent); }
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 6px;
+  margin-top: 10px;
+  margin-bottom: 10px;
   font-size: 12px;
   color: var(--text-secondary);
 }
@@ -1325,6 +1383,24 @@ kbd {
   box-shadow: 0 0 28px rgba(139, 92, 246, 0.5);
 }
 
+.setup-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  margin-left: 6px;
+  opacity: 0.7;
+}
+
 /* Secondary button */
 .setup-btn-secondary {
   padding: 8px 20px;
@@ -1341,6 +1417,15 @@ kbd {
 .setup-btn-secondary:hover {
   color: var(--text-primary);
   border-color: var(--text-muted);
+}
+
+/* AI choice buttons container */
+.setup-ai-choice-btns {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 28px;
 }
 
 /* Skip / continue in background button */

--- a/src/renderer/home.html
+++ b/src/renderer/home.html
@@ -177,47 +177,57 @@
 
         <div class="settings-section" id="ai-assistant-section">
           <h3>Local AI Assistant</h3>
-          <p>AI-powered snip organization runs locally on your machine using Ollama.</p>
-
-          <div class="ollama-checklist">
-            <div class="checklist-item">
-              <span id="check-installed" class="check-icon pending">○</span>
-              <span class="checklist-label">Ollama installed</span>
-            </div>
-            <div class="checklist-item">
-              <span id="check-running" class="check-icon pending">○</span>
-              <span class="checklist-label">Ollama running</span>
-            </div>
-            <div class="checklist-item">
-              <span id="check-model" class="check-icon pending">○</span>
-              <span class="checklist-label">Model downloaded</span>
-            </div>
+          <div class="ai-toggle-row">
+            <span class="ai-toggle-label">AI Organization</span>
+            <label class="ai-switch" id="ai-switch">
+              <input type="checkbox" id="ai-toggle-input">
+              <span class="ai-switch-track"></span>
+            </label>
           </div>
 
-          <button id="ollama-setup-btn" class="ollama-action-btn" style="margin-top: 12px;">Set up</button>
+          <div id="ai-details">
+            <p>AI-powered snip organization runs locally on your machine using Ollama.</p>
 
-          <div id="ollama-ready-info" class="hidden" style="margin-top: 12px;">
-            <div class="current-model-card">
-              <span class="current-model-label">Active Model</span>
-              <div class="current-model-header">
-                <span id="current-model-name" class="current-model-name">—</span>
-                <button class="icon-btn model-info-btn" id="model-info-btn" title="Model info">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <circle cx="12" cy="12" r="10"/>
-                    <path d="M12 16v-4"/>
-                    <circle cx="12" cy="8" r="0.5" fill="currentColor" stroke="none"/>
-                  </svg>
-                </button>
+            <div class="ollama-checklist">
+              <div class="checklist-item">
+                <span id="check-installed" class="check-icon pending">○</span>
+                <span class="checklist-label">Ollama installed</span>
               </div>
-              <div id="model-info-tooltip" class="model-info-tooltip hidden">
-                <table class="model-info-table">
-                  <tr><td class="model-info-label">Model</td><td id="info-model">—</td></tr>
-                  <tr><td class="model-info-label">Host</td><td id="info-host">—</td></tr>
-                  <tr><td class="model-info-label">Parameters</td><td id="info-params">—</td></tr>
-                  <tr><td class="model-info-label">Size</td><td id="info-size">—</td></tr>
-                  <tr><td class="model-info-label">Quantization</td><td id="info-quant">—</td></tr>
-                  <tr><td class="model-info-label">Description</td><td id="info-desc">—</td></tr>
-                </table>
+              <div class="checklist-item">
+                <span id="check-running" class="check-icon pending">○</span>
+                <span class="checklist-label">Ollama running</span>
+              </div>
+              <div class="checklist-item">
+                <span id="check-model" class="check-icon pending">○</span>
+                <span class="checklist-label">Model downloaded</span>
+              </div>
+            </div>
+
+            <button id="ollama-setup-btn" class="ollama-action-btn" style="margin-top: 12px;">Set up</button>
+
+            <div id="ollama-ready-info" class="hidden" style="margin-top: 12px;">
+              <div class="current-model-card">
+                <span class="current-model-label">Active Model</span>
+                <div class="current-model-header">
+                  <span id="current-model-name" class="current-model-name">—</span>
+                  <button class="icon-btn model-info-btn" id="model-info-btn" title="Model info">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="12" cy="12" r="10"/>
+                      <path d="M12 16v-4"/>
+                      <circle cx="12" cy="8" r="0.5" fill="currentColor" stroke="none"/>
+                    </svg>
+                  </button>
+                </div>
+                <div id="model-info-tooltip" class="model-info-tooltip hidden">
+                  <table class="model-info-table">
+                    <tr><td class="model-info-label">Model</td><td id="info-model">—</td></tr>
+                    <tr><td class="model-info-label">Host</td><td id="info-host">—</td></tr>
+                    <tr><td class="model-info-label">Parameters</td><td id="info-params">—</td></tr>
+                    <tr><td class="model-info-label">Size</td><td id="info-size">—</td></tr>
+                    <tr><td class="model-info-label">Quantization</td><td id="info-quant">—</td></tr>
+                    <tr><td class="model-info-label">Description</td><td id="info-desc">—</td></tr>
+                  </table>
+                </div>
               </div>
             </div>
           </div>
@@ -329,6 +339,34 @@
   <div id="setup-overlay" class="setup-overlay hidden">
     <div id="setup-sparkles" class="setup-sparkles"></div>
 
+    <!-- AI choice view (first-launch opt-in/out) -->
+    <div id="setup-ai-choice-view" class="setup-view hidden">
+      <div class="setup-header">
+        <div class="setup-header-icon">
+          <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+            <rect x="22" y="20" width="4" height="24" rx="2" transform="rotate(-45 22 20)" fill="var(--accent)" opacity="0.85"/>
+            <path d="M14 6L16 11.5L21.5 13L16 15L14 20.5L12 15L6.5 13L12 11.5L14 6Z" fill="var(--accent)"/>
+            <path d="M8 24L9 26.5L11.5 27.5L9 28.5L8 31L7 28.5L4.5 27.5L7 26.5L8 24Z" fill="var(--accent)" opacity="0.5"/>
+            <path d="M26 4L26.8 6L28.8 6.8L26.8 7.6L26 9.6L25.2 7.6L23.2 6.8L25.2 6L26 4Z" fill="var(--accent)" opacity="0.4"/>
+            <circle cx="21" cy="3" r="1.2" fill="var(--accent)" opacity="0.35"/>
+            <circle cx="4" cy="16" r="1" fill="var(--accent)" opacity="0.3"/>
+          </svg>
+        </div>
+        <h2>Smart Organization</h2>
+        <p>Snip can use a local AI to automatically name, tag, and organize your snips. Everything runs on your machine.</p>
+      </div>
+      <div class="setup-ai-choice-btns">
+        <button id="setup-ai-enable-btn" class="setup-btn-icon setup-btn-glow">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M5 12h14"/>
+            <path d="M12 5l7 7-7 7"/>
+          </svg>
+          Enable <kbd class="setup-kbd">Y</kbd>
+        </button>
+        <button id="setup-ai-skip-btn" class="setup-btn-skip">Skip for now <kbd class="setup-kbd">N</kbd></button>
+      </div>
+    </div>
+
     <!-- Steps view (install / running / model) -->
     <div id="setup-steps-view" class="setup-view">
       <div class="setup-header">
@@ -362,7 +400,7 @@
                   <polyline points="7 10 12 15 17 10"/>
                   <line x1="12" y1="15" x2="12" y2="3"/>
                 </svg>
-                Install
+                Install <kbd class="setup-kbd">Enter</kbd>
               </button>
               <div id="setup-install-progress" class="setup-progress hidden">
                 <div class="setup-progress-track">
@@ -406,7 +444,7 @@
                   <polyline points="7 10 12 15 17 10"/>
                   <line x1="12" y1="15" x2="12" y2="3"/>
                 </svg>
-                Download
+                Download <kbd class="setup-kbd">Enter</kbd>
               </button>
               <div id="setup-model-progress" class="setup-progress hidden">
                 <div class="setup-progress-track">
@@ -423,7 +461,7 @@
         </div>
       </div>
 
-      <button id="setup-skip-btn" class="setup-btn-skip">Skip for now</button>
+      <button id="setup-skip-btn" class="setup-btn-skip">Skip for now <kbd class="setup-kbd">Esc</kbd></button>
     </div>
 
     <!-- Welcome view -->
@@ -449,7 +487,7 @@
           <path d="M5 12h14"/>
           <path d="M12 5l7 7-7 7"/>
         </svg>
-        Let's go
+        Let's go <kbd class="setup-kbd">Enter</kbd>
       </button>
     </div>
 
@@ -464,8 +502,8 @@
       <h2 class="setup-failed-title">Snip works great without AI too</h2>
       <p class="setup-failed-desc">You can capture, annotate, and save snips. AI organization can be set up later from Settings.</p>
       <div class="setup-failed-btns">
-        <button id="setup-continue-without" class="setup-btn-primary">Continue without AI</button>
-        <button id="setup-try-again" class="setup-btn-secondary">Try again</button>
+        <button id="setup-continue-without" class="setup-btn-primary">Continue without AI <kbd class="setup-kbd">Esc</kbd></button>
+        <button id="setup-try-again" class="setup-btn-secondary">Try again <kbd class="setup-kbd">Enter</kbd></button>
       </div>
     </div>
   </div>

--- a/src/renderer/home.js
+++ b/src/renderer/home.js
@@ -321,6 +321,18 @@
     hideContextMenu();
   });
 
+  // ── AI settings visibility ──
+  function updateAiSettingsVisibility(enabled) {
+    var details = document.getElementById('ai-details');
+    var toggle = document.getElementById('ai-toggle-input');
+    if (details) {
+      details.style.display = enabled === false ? 'none' : '';
+    }
+    if (toggle) {
+      toggle.checked = enabled !== false;
+    }
+  }
+
   // ── Settings: Local AI Assistant (Ollama) ──
 
   var MODEL_SPECS = {
@@ -333,6 +345,19 @@
     setupBtn.addEventListener('click', function() {
       if (window._showSetupOverlay) window._showSetupOverlay();
     });
+
+    // AI on/off toggle switch
+    var aiToggle = document.getElementById('ai-toggle-input');
+    if (aiToggle) {
+      aiToggle.addEventListener('change', async function() {
+        var enabled = aiToggle.checked;
+        await window.snip.setAiEnabled(enabled);
+        updateAiSettingsVisibility(enabled);
+        if (enabled) {
+          refreshOllamaChecklist();
+        }
+      });
+    }
 
     // Info tooltip toggle
     var infoBtn = document.getElementById('model-info-btn');
@@ -397,10 +422,8 @@
       } else if (!status.modelReady) {
         setupBtn.textContent = 'Finish setup';
       }
-      // Keep polling if partially ready
-      if (status.installed && !status.running) {
-        setTimeout(refreshOllamaChecklist, 3000);
-      }
+      // Keep polling until all ready (Ollama may be starting in background)
+      setTimeout(refreshOllamaChecklist, 1000);
     }
   }
 
@@ -842,6 +865,9 @@
     var screen = determineSetupScreen(status);
     if (screen) {
       applySetupScreen(screen, status);
+    } else if (setupFromSettings) {
+      // From Settings — just dismiss, no welcome screen
+      hideSetupOverlay();
     } else {
       showSetupView('welcome');
       burstSparkles(30);
@@ -874,6 +900,22 @@
     var modelBtn = document.getElementById('setup-model-btn');
     var skipBtn = document.getElementById('setup-skip-btn');
 
+    // AI choice buttons
+    var aiEnableBtn = document.getElementById('setup-ai-enable-btn');
+    var aiSkipBtn = document.getElementById('setup-ai-skip-btn');
+
+    aiEnableBtn.addEventListener('click', async function() {
+      await window.snip.setAiEnabled(true);
+      updateAiSettingsVisibility(true);
+      applySetupStatus(await window.snip.getOllamaStatus());
+    });
+
+    aiSkipBtn.addEventListener('click', async function() {
+      await window.snip.setAiEnabled(false);
+      updateAiSettingsVisibility(false);
+      hideSetupOverlay();
+    });
+
     // Action buttons — both primary and retry share the same handler
     var installAction = function() { startSetupAction('install', installBtn, skipBtn, window.snip.installOllama); };
     var modelAction = function() { startSetupAction('model', modelBtn, skipBtn, window.snip.pullOllamaModel); };
@@ -889,9 +931,26 @@
       dismissBtns[i].addEventListener('click', hideSetupOverlay);
     }
 
-    // Enter key triggers the primary action for the active setup screen
+    // Keyboard shortcuts for setup overlay
     document.addEventListener('keydown', function(e) {
-      if (e.key !== 'Enter' || overlay.classList.contains('hidden')) return;
+      if (overlay.classList.contains('hidden')) return;
+
+      // AI choice screen — Y to enable, N to skip
+      var aiChoiceView = document.getElementById('setup-ai-choice-view');
+      if (aiChoiceView && !aiChoiceView.classList.contains('hidden')) {
+        if (e.key === 'y' || e.key === 'Y') { aiEnableBtn.click(); return; }
+        if (e.key === 'n' || e.key === 'N') { aiSkipBtn.click(); return; }
+        if (e.key === 'Enter') { aiEnableBtn.click(); return; }
+        return;
+      }
+
+      // Escape → skip / continue in background
+      if (e.key === 'Escape') {
+        hideSetupOverlay();
+        return;
+      }
+
+      if (e.key !== 'Enter') return;
 
       // Welcome screen → dismiss
       var welcomeView = document.getElementById('setup-welcome-view');
@@ -944,7 +1003,12 @@
     window.snip.onOllamaStatusChanged(function() { refreshSetupOverlay(); });
 
     if (window.snip.onShowSetupOverlay) {
-      window.snip.onShowSetupOverlay(function() { showSetupOverlay(); });
+      window.snip.onShowSetupOverlay(function() {
+        // Don't override the AI choice view if it's showing
+        var aiChoiceView = document.getElementById('setup-ai-choice-view');
+        if (aiChoiceView && !aiChoiceView.classList.contains('hidden')) return;
+        showSetupOverlay();
+      });
     }
 
     window._showSetupOverlay = function() {
@@ -956,20 +1020,30 @@
   }
 
   async function checkAndShowSetup() {
-    try {
-      var status = await window.snip.getOllamaStatus();
-      if (determineSetupScreen(status)) {
-        document.getElementById('setup-overlay').classList.remove('hidden');
-        applySetupScreen(determineSetupScreen(status), status);
-      }
-    } catch (err) {
+    var aiEnabled = await window.snip.getAiEnabled();
+
+    // Sync toggle to current state
+    updateAiSettingsVisibility(aiEnabled === true ? true : false);
+
+    // First launch — show AI choice screen
+    if (aiEnabled === undefined || aiEnabled === null) {
       document.getElementById('setup-overlay').classList.remove('hidden');
-      applySetupScreen('install', FALLBACK_STATUS);
+      showSetupView('ai-choice');
+      return;
     }
+
+    // AI disabled or already enabled — no overlay on launch.
+    // User can manage setup from Settings if needed.
+    return;
   }
 
   async function showSetupOverlay() {
     document.getElementById('setup-overlay').classList.remove('hidden');
+    // When opened from Settings, set aiEnabled=true and skip choice view
+    if (setupFromSettings) {
+      await window.snip.setAiEnabled(true);
+      updateAiSettingsVisibility(true);
+    }
     try {
       applySetupStatus(await window.snip.getOllamaStatus());
     } catch (err) {
@@ -998,7 +1072,7 @@
   }
 
   function showSetupView(viewName) {
-    var views = { steps: 'setup-steps-view', welcome: 'setup-welcome-view', failed: 'setup-failed-view' };
+    var views = { 'ai-choice': 'setup-ai-choice-view', steps: 'setup-steps-view', welcome: 'setup-welcome-view', failed: 'setup-failed-view' };
     var keys = Object.keys(views);
     for (var i = 0; i < keys.length; i++) {
       document.getElementById(views[keys[i]]).classList.add('hidden');
@@ -1014,8 +1088,12 @@
     } else if (viewName === 'failed') {
       document.getElementById(views.failed).classList.remove('hidden');
       stopSparkles();
+    } else if (viewName === 'ai-choice') {
+      document.getElementById(views['ai-choice']).classList.remove('hidden');
+      startSparkles();
     } else {
       document.getElementById(views.steps).classList.remove('hidden');
+      startSparkles();
     }
   }
 

--- a/src/renderer/theme.css
+++ b/src/renderer/theme.css
@@ -24,6 +24,7 @@
   --bg-primary: rgba(20, 20, 20, 0.75);
   --bg-secondary: rgba(18, 18, 18, 0.8);
   --bg-elevated: rgba(40, 40, 40, 0.7);
+  --bg-tertiary: rgba(255, 255, 255, 0.1);
   --bg-toolbar: rgba(25, 25, 25, 0.6);
   --bg-hover: rgba(255, 255, 255, 0.06);
   --bg-hover-strong: rgba(255, 255, 255, 0.12);
@@ -99,6 +100,7 @@
   --bg-primary: rgba(255, 253, 250, 0.7);
   --bg-secondary: rgba(250, 247, 242, 0.8);
   --bg-elevated: rgba(255, 255, 255, 0.75);
+  --bg-tertiary: rgba(0, 0, 0, 0.06);
   --bg-toolbar: rgba(255, 253, 250, 0.6);
   --bg-hover: rgba(139, 92, 246, 0.06);
   --bg-hover-strong: rgba(139, 92, 246, 0.1);
@@ -179,6 +181,7 @@
   --bg-primary: rgba(25, 12, 50, 0.20);
   --bg-secondary: rgba(25, 12, 50, 0.30);
   --bg-elevated: rgba(30, 15, 60, 0.32);
+  --bg-tertiary: rgba(139, 92, 246, 0.15);
   --bg-toolbar: rgba(25, 12, 50, 0.28);
   --bg-hover: rgba(139, 92, 246, 0.20);
   --bg-hover-strong: rgba(139, 92, 246, 0.30);
@@ -262,6 +265,7 @@
     --bg-primary: #141414;
     --bg-secondary: #121212;
     --bg-elevated: #1e1e1e;
+    --bg-tertiary: #2a2a2a;
     --bg-toolbar: #191919;
     --bg-toast: #141414;
     --bg-overlay: rgba(0, 0, 0, 0.6);
@@ -280,6 +284,7 @@
     --bg-primary: #FFFDF9;
     --bg-secondary: #F7F3EC;
     --bg-elevated: #FFFFFF;
+    --bg-tertiary: #EFECE6;
     --bg-toolbar: #FFFDF9;
     --bg-toast: #FFFDF9;
     --bg-overlay: rgba(0, 0, 0, 0.3);
@@ -298,6 +303,7 @@
     --bg-primary: #140f20;
     --bg-secondary: #1a1428;
     --bg-elevated: #221a30;
+    --bg-tertiary: #2a1e3d;
     --bg-toolbar: #181228;
     --bg-toast: #1a1428;
     --bg-overlay: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Summary
- Adds an AI choice screen as the first step in onboarding, letting users opt out of local AI (Ollama) entirely
- Persists `aiEnabled` preference in config — `undefined` (first launch) triggers the choice screen, `false` skips Ollama lifecycle, `true` runs normally
- Adds a toggle switch in Settings to enable/disable AI after onboarding, with Ollama start/stop on toggle
- Improves search to include non-AI-indexed images (filename + metadata text match) at the bottom of results
- Adds keyboard shortcuts (Y/N/Enter/Esc) and sparkle animations across all setup wizard views
- Redesigns segment tool tutorial with structured steps and kbd badges

## Changes
- **`src/main/store.js`** — `getAiEnabled()` / `setAiEnabled()` config persistence
- **`src/preload/preload.js`** — IPC bridge for ai-enabled preference
- **`src/main/ipc-handlers.js`** — Handlers with Ollama lifecycle management on toggle
- **`src/main/main.js`** — Gate Ollama startup on `aiEnabled === true`
- **`src/main/organizer/watcher.js`** — Skip agent processing when AI disabled
- **`src/main/organizer/embeddings.js`** — Merge semantic + text search results
- **`src/renderer/home.html`** — AI choice view, toggle switch in settings, kbd hints
- **`src/renderer/home.js`** — Setup flow state machine, toggle handler, keyboard shortcuts
- **`src/renderer/home.css`** — Choice buttons, toggle switch, kbd badge styles
- **`src/renderer/theme.css`** — Added `--bg-tertiary` variable to all theme blocks
- **`src/renderer/editor.html`** + **`editor-styles.css`** — Redesigned segment tutorial
- **Docs** — Updated USER_FLOWS.md, PRODUCT.md, ARCHITECTURE.md

## Test plan
- [ ] Delete config (`rm ~/Library/Application\ Support/snip/snip-config.json`) and launch — AI choice screen appears
- [ ] Click "Skip for now" (or press N) — overlay dismissed, config has `aiEnabled: false`, no Ollama process
- [ ] Take a screenshot — saved with basic metadata, appears in search by filename
- [ ] Relaunch — no overlay flash, no Ollama startup
- [ ] Settings → toggle AI on → Ollama starts, setup checklist progresses
- [ ] Settings → "Set up" button → goes straight to steps view (skips AI choice)
- [ ] Fresh config → click "Enable" (or press Y) → proceeds to Ollama install/model flow
- [ ] Verify keyboard shortcuts: Y/N on choice screen, Enter/Esc on other views

🤖 Generated with [Claude Code](https://claude.com/claude-code)