### PR TITLE
Bundle standalone Node.js binary for SAM segmentation, drop x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ permissions:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        arch: [arm64, x64]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,10 +25,13 @@ jobs:
       - run: npm ci
 
       - name: Rebuild native modules for target arch
-        run: npx node-gyp rebuild --arch=${{ matrix.arch }}
+        run: npx node-gyp rebuild --arch=arm64
 
       - name: Download HuggingFace models
         run: node scripts/download-models.js
+
+      - name: Download bundled Node.js binary
+        run: node scripts/download-node.js --arch arm64
 
       - name: Build, sign & notarize
         env:
@@ -40,11 +40,11 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npx electron-builder --mac dmg --${{ matrix.arch }} --publish never
+        run: npx electron-builder --mac dmg --arm64 --publish never
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dmg-${{ matrix.arch }}
+          name: dmg-arm64
           path: dist/*.dmg
 
   release:
@@ -57,7 +57,6 @@ jobs:
         with:
           files: |
             dmg-arm64/*.dmg
-            dmg-x64/*.dmg
           draft: false
           generate_release_notes: true
 
@@ -74,29 +73,20 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           DMG_ARM64="https://github.com/rixinhahaha/snip/releases/download/v${VERSION}/Snip-${VERSION}-arm64.dmg"
-          DMG_X64="https://github.com/rixinhahaha/snip/releases/download/v${VERSION}/Snip-${VERSION}-x64.dmg"
           SHA_ARM64=$(curl -sL "$DMG_ARM64" | shasum -a 256 | cut -d' ' -f1)
-          SHA_X64=$(curl -sL "$DMG_X64" | shasum -a 256 | cut -d' ' -f1)
 
           cat > Casks/snip.rb << EOF
           cask "snip" do
             version "${VERSION}"
+            sha256 "${SHA_ARM64}"
 
-            on_arm do
-              sha256 "${SHA_ARM64}"
-              url "https://github.com/rixinhahaha/snip/releases/download/v#{version}/Snip-#{version}-arm64.dmg"
-            end
-
-            on_intel do
-              sha256 "${SHA_X64}"
-              url "https://github.com/rixinhahaha/snip/releases/download/v#{version}/Snip-#{version}-x64.dmg"
-            end
-
+            url "https://github.com/rixinhahaha/snip/releases/download/v#{version}/Snip-#{version}-arm64.dmg"
             name "Snip"
             desc "Screenshot app with annotation, AI-powered organization, and semantic search"
             homepage "https://github.com/rixinhahaha/snip"
 
             depends_on macos: ">= :ventura"
+            depends_on arch: :arm64
 
             livecheck do
               url :url

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ Thumbs.db
 # Bundled vendor models (downloaded via node scripts/download-models.js)
 vendor/models/
 
+# Bundled Node.js binary (downloaded via node scripts/download-node.js)
+vendor/node/
+
 # Claude Code (user-specific session data)
 .claude/
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Capture a region of your screen, annotate with shapes, text, blur, or AI segment
 brew install --cask rixinhahaha/snip/snip
 ```
 
-Or download the DMG directly from [Releases](https://github.com/rixinhahaha/snip/releases) (Apple Silicon and Intel).
+Or download the DMG directly from [Releases](https://github.com/rixinhahaha/snip/releases) (Apple Silicon only).
 
 ## Quick Start (Development)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,11 +87,14 @@ site/                        # Marketing site (GitHub Pages, snipit.dev)
   assets/                      # Hero video, screenshots, OG image
 scripts/                     # Build and generation scripts
   download-models.js           # Download MiniLM + SlimSAM to vendor/models/
+  download-node.js             # Download standalone Node.js binary to vendor/node/
   afterPack.js                 # electron-builder afterPack hook (strip unused native modules, pre-sign)
   build-signed.sh              # Production build: sign + notarize
   generate-app-icon.js         # Regenerate app icons from SVG template
 vendor/                      # Downloaded at dev time, bundled at build time
   models/                      # HuggingFace models: MiniLM + SlimSAM (~75 MB)
+  node/                        # Standalone Node.js binary for SAM subprocess (~100 MB)
+    arm64/node                   # Apple Silicon
   (static animation presets inlined in src/main/animation/animation.js)
 ```
 
@@ -147,7 +150,7 @@ Both Transformers.js models are **pre-downloaded and bundled** — no runtime do
 ONNX Runtime (via Transformers.js) **crashes in worker_threads**. Embeddings must run on the main Electron thread. The worker thread handles Ollama API calls, then delegates embedding generation back to main via message passing.
 
 ### SAM in Child Process
-The segmentation model (SlimSAM) runs in a **child process** (`child_process.fork`), not a worker thread, because ONNX Runtime also crashes in Electron's V8 worker context. The child process uses the system-installed Node.js binary (not Electron's). The parent passes `SNIP_MODELS_PATH` and `SNIP_PACKAGED` env vars so the worker uses bundled models.
+The segmentation model (SlimSAM) runs in a **child process** (`child_process.fork`), not a worker thread, because ONNX Runtime also crashes in Electron's V8 worker context. The child process uses a standalone Node.js binary (not Electron's). A bundled Node.js binary is included in the packaged app (`Resources/node/node`) so the segment tool works without requiring users to install developer tools. In development, `vendor/node/{arch}/node` is checked first, then system Node.js installs (NVM, homebrew, PATH, FNM). The parent passes `SNIP_MODELS_PATH` and `SNIP_PACKAGED` env vars so the worker uses bundled models.
 
 ### fal.ai Cloud Animation
 The Animate feature uses the **fal.ai Wan 2.2 A14B image-to-video API** instead of a local model. This requires an internet connection and a fal.ai API key (set in Settings). When the user clicks Animate, Ollama's minicpm-v vision model analyzes the cutout and generates 3 AI-tailored animation presets (e.g., "wag tail" for a dog). If Ollama is unavailable, it falls back to 6 static presets inlined in `animation.js`. Users can also enter a custom animation prompt. All animations are capped at **4 seconds maximum** (enforced via `MAX_DURATION_SECONDS` in `animation.js` and `maxDuration` in `gif-encoder-worker.js`). The pipeline:

--- a/docs/DEVOPS.md
+++ b/docs/DEVOPS.md
@@ -9,7 +9,7 @@
 | Requirement | Why |
 |-------------|-----|
 | **macOS** 10.13+ | Electron target platform (macOS 26+ for Liquid Glass) |
-| **Node.js** 18+ | System Node.js required for SAM segmentation subprocess |
+| **Node.js** 18+ | Used during development; a standalone Node.js binary is bundled for the packaged app |
 | **Xcode CLT** | `xcode-select --install` — compiles native `window_utils.node` addon |
 | **Screen Recording permission** | Required for `desktopCapturer` — grant in System Settings > Privacy |
 
@@ -30,6 +30,9 @@ npm run rebuild
 #   - MiniLM (~23 MB) — embedding model for semantic search
 #   - SlimSAM (~50 MB) — segmentation model for object selection
 npm run download-models
+
+# Download Node.js binary for SAM subprocess (run once, ~100 MB)
+npm run download-node
 
 # Launch in dev mode (verbose logging)
 npm run dev
@@ -53,12 +56,11 @@ The app runs as a **tray-only** process (no Dock icon). Look for the scissors ic
 | `npm run rebuild` | `electron-rebuild` — recompile all native modules for Electron's Node ABI |
 | `npm run prebuild` | `node-gyp rebuild` — compile just the `window_utils.node` addon |
 | `npm run build` | Full build for arm64: `node-gyp rebuild` + `electron-builder --mac --arm64` + ad-hoc sign |
-| `npm run build:x64` | Full build for x64 (Intel): `node-gyp rebuild --arch=x64` + `electron-builder --mac --x64` + ad-hoc sign |
 | `npm run sign:adhoc` | Ad-hoc `codesign` for local use (no Developer ID needed) |
-| `./scripts/build-signed.sh` | Production build (host arch): loads `.env` creds, validates cert, builds + signs + notarizes |
-| `./scripts/build-signed.sh --arch x64` | Production build for Intel |
+| `./scripts/build-signed.sh` | Production build (arm64): loads `.env` creds, validates cert, builds + signs + notarizes |
 | `node scripts/generate-app-icon.js` | Regenerate `assets/icon.png` and `assets/icon.icns` from SVG template |
 | `npm run download-models` | Download HuggingFace models: MiniLM (~23 MB), SlimSAM (~50 MB). Note: Ollama and minicpm-v are NOT bundled — installed at runtime. |
+| `npm run download-node` | Download standalone Node.js 22 LTS binary (~100 MB) for SAM segmentation subprocess (arm64 only). |
 
 ---
 
@@ -109,10 +111,11 @@ npm run build
 1. `node-gyp rebuild` compiles `window_utils.node`
 2. `electron-builder --mac` packages the app
 3. `afterPack` hook in `electron-builder.yml`:
+   - Copies arch-specific bundled Node.js binary to `Resources/node/node`
    - Removes unused native modules (`canvas`)
    - Strips non-macOS ONNX Runtime binaries
    - Removes wrong-arch `electron-liquid-glass` prebuilds
-   - Pre-signs remaining `.node` and `.dylib` files
+   - Pre-signs remaining `.node`, `.dylib` files and the bundled Node.js binary
 4. No `CSC_LINK` detected -> `sign:adhoc` runs `codesign --force --deep --sign -`
 5. Output: `dist/mac-{arch}/Snip.app` + `Snip-{version}-{arch}.dmg`
 
@@ -123,7 +126,6 @@ DMGs use the format `Snip-{version}-{arch}.dmg` (configured via `artifactName` i
 | Architecture | Example |
 |-------------|---------|
 | Apple Silicon | `Snip-1.0.9-arm64.dmg` |
-| Intel | `Snip-1.0.9-x64.dmg` |
 
 ### Production Build (Signed + Notarized)
 
@@ -152,7 +154,7 @@ base64 -i certificate.p12 | tr -d '\n' | pbcopy
 1. Loads `.env` credentials, validates cert type
 2. `npm run prebuild` compiles native addon
 3. `electron-builder --mac` assembles + signs with Developer ID cert
-4. `afterPack` hook cleans unused modules, removes wrong-arch prebuilds, pre-signs native binaries
+4. `afterPack` hook copies bundled Node.js binary, cleans unused modules, removes wrong-arch prebuilds, pre-signs native binaries
 5. App submitted to Apple notary service
 6. Notarization ticket stapled to DMG on success
 7. Output: signed + notarized `dist/Snip-{version}-{arch}.dmg`
@@ -175,7 +177,7 @@ git tag v1.0.9
 git push origin v1.0.9
 ```
 
-The workflow downloads HuggingFace models, builds both arm64 and x64 DMGs (with models bundled), creates a GitHub release, and auto-updates the Homebrew cask with architecture-specific URLs.
+The workflow downloads HuggingFace models and the Node.js binary, builds an arm64 DMG (with models and Node.js bundled), creates a GitHub release, and auto-updates the Homebrew cask.
 
 ### Homebrew
 
@@ -200,6 +202,7 @@ The cask is hosted at [`rixinhahaha/homebrew-snip`](https://github.com/rixinhaha
 | Ollama binary | `/usr/local/bin/ollama`, `/opt/homebrew/bin/ollama`, or `/Applications/Ollama.app/Contents/Resources/ollama` | User-installed (or installed via in-app setup wizard) |
 | Ollama models | `~/.ollama/models/` | Shared with system Ollama; minicpm-v pulled on first launch |
 | HF models (MiniLM + SlimSAM) | `vendor/models/` (dev) / `Resources/models/` (packaged) | Bundled — `npm run download-models --hf` (~75 MB) |
+| Node.js binary (SAM subprocess) | `vendor/node/{arch}/node` (dev) / `Resources/node/node` (packaged) | Bundled — `npm run download-node` (~100 MB) |
 | Animation presets | Inlined in `src/main/animation/animation.js` | 6 static text-prompt presets (fallback when Ollama AI presets unavailable) |
 
 ---
@@ -224,7 +227,7 @@ The cask is hosted at [`rixinhahaha/homebrew-snip`](https://github.com/rixinhaha
 | `npm run rebuild` fails | Install Xcode CLT: `xcode-select --install` |
 | No tray icon visible | Check `assets/tray-iconTemplate.png` exists (Template suffix = auto dark/light) |
 | Screen capture blank | Grant Screen Recording permission, restart app |
-| SAM segment tool hidden | Needs 4GB+ RAM and system Node.js (not Electron's bundled one) |
+| SAM segment tool hidden | Needs 4GB+ RAM. Run `npm run download-node` to bundle the Node.js binary (auto-detected in packaged app). Falls back to system Node.js if bundled binary not found. |
 | Animation (Animate) fails | Check fal.ai API key is set in Settings → Animation, and internet connection is available |
 | `electron-liquid-glass` fails | Only works on macOS 26+; older macOS falls back to vibrancy |
 | App switches Spaces on capture | Ensure `app.dock.hide()` is running and native module built |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,7 +11,6 @@ mac:
     - target: dmg
       arch:
         - arm64
-        - x64
   darkModeSupport: true
   hardenedRuntime: true
   gatekeeperAssess: false

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "postinstall": "electron-builder install-app-deps",
     "prebuild": "node-gyp rebuild",
     "build": "node-gyp rebuild && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac --arm64 && npm run sign:adhoc",
-    "build:x64": "node-gyp rebuild --arch=x64 && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac --x64 && npm run sign:adhoc",
     "sign:adhoc": "for app in dist/mac-*/Snip.app; do if codesign -v \"$app\" 2>/dev/null; then echo \"Already signed: $app\"; else codesign --force --deep --sign - \"$app\" 2>/dev/null && echo \"Ad-hoc signed: $app\"; fi; done",
     "download-models": "node scripts/download-models.js",
+    "download-node": "node scripts/download-node.js",
     "rebuild": "electron-rebuild"
   },
   "dependencies": {

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -3,10 +3,11 @@
  *
  * Runs after the app directory is assembled but BEFORE electron-builder signs
  * the app bundle. This hook:
- *   1. Removes canvas native module (unused transitive dep)
- *   2. Removes non-macOS onnxruntime binaries (used by @huggingface/transformers)
- *   3. Removes wrong-arch darwin binaries (keep only the target arch)
- *   4. Pre-signs remaining .node and .dylib files with Developer ID cert
+ *   1. Copies the arch-specific bundled Node.js binary into Resources/node/
+ *   2. Removes canvas native module (unused transitive dep)
+ *   3. Removes non-macOS onnxruntime binaries (used by @huggingface/transformers)
+ *   4. Removes wrong-arch darwin binaries (keep only the target arch)
+ *   5. Pre-signs remaining .node and .dylib files with Developer ID cert
  *
  * Note: Ollama is NOT bundled — users install it separately via ollama.com.
  */
@@ -55,22 +56,36 @@ module.exports = async function afterPack(context) {
     return;
   }
 
-  // electron-builder Arch enum: 0=x64, 1=ia32, 2=armv7l, 3=arm64, 4=universal
-  var archMap = { 0: 'x64', 1: 'ia32', 2: 'armv7l', 3: 'arm64', 4: 'universal' };
-  var targetArch = archMap[context.arch] || 'arm64';
+  // electron-builder Arch enum: 3=arm64 (only arch we support)
+  var targetArch = 'arm64';
   console.log('[afterPack] Target architecture: ' + targetArch);
 
   // ---------------------------------------------------------------
-  // 1. Remove unused native modules (canvas)
-  //    Note: sharp and @img are kept — @huggingface/transformers
-  //    has a hard static import of sharp that crashes if missing.
+  // 1. Copy arch-specific bundled Node.js binary
+  //    electron-builder's extraResources doesn't interpolate ${arch}
+  //    in from paths, so we copy the correct binary here.
+  // ---------------------------------------------------------------
+  var vendorNodeSrc = path.join(__dirname, '..', 'vendor', 'node', targetArch, 'node');
+  var nodeDestDir = path.join(resourcesDir, 'node');
+  var nodeDestFile = path.join(nodeDestDir, 'node');
+  if (fs.existsSync(vendorNodeSrc)) {
+    fs.mkdirSync(nodeDestDir, { recursive: true });
+    fs.copyFileSync(vendorNodeSrc, nodeDestFile);
+    fs.chmodSync(nodeDestFile, 0o755);
+    console.log('[afterPack] Copied bundled Node.js binary for ' + targetArch);
+  } else {
+    console.warn('[afterPack] No bundled Node.js binary found at ' + vendorNodeSrc + ' — segment tool may not work');
+  }
+
+  // ---------------------------------------------------------------
+  // 2. Remove unused native modules (canvas)
   // ---------------------------------------------------------------
   var nmDir = path.join(unpackedDir, 'node_modules');
 
   removeDir(path.join(nmDir, 'canvas'), 'canvas (unused transitive dep)');
 
   // ---------------------------------------------------------------
-  // 2. Remove non-macOS onnxruntime binaries
+  // 3. Remove non-macOS onnxruntime binaries
   // ---------------------------------------------------------------
   var onnxBinDir = path.join(nmDir, 'onnxruntime-node', 'bin', 'napi-v3');
   if (fs.existsSync(onnxBinDir)) {
@@ -83,7 +98,7 @@ module.exports = async function afterPack(context) {
     }
 
     // ---------------------------------------------------------------
-    // 3. Remove wrong-arch darwin binaries
+    // 3b. Remove wrong-arch darwin binaries
     // ---------------------------------------------------------------
     if (targetArch !== 'universal') {
       var darwinDir = path.join(onnxBinDir, 'darwin');
@@ -102,7 +117,7 @@ module.exports = async function afterPack(context) {
   }
 
   // ---------------------------------------------------------------
-  // 2b. Remove wrong-arch electron-liquid-glass prebuilds
+  // 3c. Remove wrong-arch electron-liquid-glass prebuilds
   // ---------------------------------------------------------------
   var elgPrebuildsDir = path.join(nmDir, 'electron-liquid-glass', 'prebuilds');
   if (fs.existsSync(elgPrebuildsDir)) {
@@ -119,7 +134,7 @@ module.exports = async function afterPack(context) {
   }
 
   // ---------------------------------------------------------------
-  // 2c. Remove wrong-platform/arch @img/sharp-* packages
+  // 3d. Remove wrong-platform/arch @img/sharp-* packages
   //     npm only installs the matching platform, but strip any
   //     that don't match darwin-{targetArch} as a safety net.
   // ---------------------------------------------------------------
@@ -142,7 +157,7 @@ module.exports = async function afterPack(context) {
   }
 
   // ---------------------------------------------------------------
-  // 4. Pre-sign remaining native binaries
+  // 5. Pre-sign remaining native binaries
   //    electron-builder will sign the whole app bundle after this
   //    hook, but third-party .dylib/.node files sometimes need to
   //    be individually signed first for notarization to pass.
@@ -167,6 +182,12 @@ module.exports = async function afterPack(context) {
 
   var nativeDir = path.join(resourcesDir, 'native');
   findFiles(nativeDir, nativeBinaryPattern, binaries);
+
+  // Also sign the bundled Node.js binary
+  var bundledNode = path.join(resourcesDir, 'node', 'node');
+  if (fs.existsSync(bundledNode)) {
+    binaries.push(bundledNode);
+  }
 
   if (binaries.length === 0) {
     console.log('[afterPack] No native binaries found to pre-sign');

--- a/scripts/build-signed.sh
+++ b/scripts/build-signed.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 #
 # build-signed.sh — Load Apple Developer credentials from .env and build
-# a signed + notarized Snip DMG in one command.
+# a signed + notarized Snip DMG in one command (arm64 only).
 #
 # Usage:
-#   ./scripts/build-signed.sh                 # build for host arch (arm64 or x64)
-#   ./scripts/build-signed.sh --arch x64      # build for Intel
-#   ./scripts/build-signed.sh --arch arm64    # build for Apple Silicon
+#   ./scripts/build-signed.sh
 #   ENV_FILE=path/to/.env ./scripts/build-signed.sh  # custom .env path
 #
 set -euo pipefail
@@ -15,26 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENV_FILE="${ENV_FILE:-$PROJECT_ROOT/.env}"
 
-# ── Parse --arch flag ─────────────────────────────────────────
-TARGET_ARCH=""
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --arch) TARGET_ARCH="$2"; shift 2 ;;
-    *) shift ;;
-  esac
-done
-
-# Default to host architecture
-if [ -z "$TARGET_ARCH" ]; then
-  TARGET_ARCH=$(uname -m)
-  [ "$TARGET_ARCH" = "x86_64" ] && TARGET_ARCH="x64"
-fi
-
-if [ "$TARGET_ARCH" != "arm64" ] && [ "$TARGET_ARCH" != "x64" ]; then
-  echo "❌ Unsupported arch: $TARGET_ARCH (use arm64 or x64)"
-  exit 1
-fi
-
+TARGET_ARCH="arm64"
 echo "🎯 Target architecture: $TARGET_ARCH"
 
 if [ ! -f "$ENV_FILE" ]; then
@@ -89,11 +68,11 @@ cd "$PROJECT_ROOT"
 
 echo ""
 echo "🔨 Building native modules for $TARGET_ARCH..."
-node-gyp rebuild --arch="$TARGET_ARCH"
+node-gyp rebuild
 
 echo ""
 echo "🏗️  Building signed DMG ($TARGET_ARCH)..."
-npx electron-builder --mac --"$TARGET_ARCH"
+npx electron-builder --mac --arm64
 
 echo ""
 echo "✅ Build complete! Output in dist/"

--- a/scripts/download-node.js
+++ b/scripts/download-node.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Download Node.js binary for bundling with the packaged app.
+ *
+ * The SAM segmentation child process needs a standalone Node.js binary
+ * because ONNX Runtime crashes inside Electron's V8. This script downloads
+ * only the `bin/node` executable from the official Node.js distribution.
+ *
+ * Usage:
+ *   node scripts/download-node.js              # current arch (arm64)
+ *   node scripts/download-node.js --arch arm64  # explicit
+ *
+ * Output:
+ *   vendor/node/{arch}/node   (~100 MB uncompressed)
+ */
+
+var path = require('path');
+var fs = require('fs');
+var https = require('https');
+var { execSync } = require('child_process');
+
+var NODE_VERSION = '22.14.0';
+var PROJECT_DIR = path.join(__dirname, '..');
+var VENDOR_NODE = path.join(PROJECT_DIR, 'vendor', 'node');
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' KB';
+  if (bytes < 1073741824) return (bytes / 1048576).toFixed(1) + ' MB';
+  return (bytes / 1073741824).toFixed(2) + ' GB';
+}
+
+function parseArgs() {
+  var arch = process.arch;
+  var args = process.argv.slice(2);
+  for (var i = 0; i < args.length; i++) {
+    if (args[i] === '--arch' && args[i + 1]) {
+      arch = args[i + 1];
+      i++;
+    }
+  }
+  return arch;
+}
+
+function httpsGet(url) {
+  return new Promise(function (resolve, reject) {
+    https.get(url, function (res) {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        httpsGet(res.headers.location).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode !== 200) {
+        reject(new Error('HTTP ' + res.statusCode + ' for ' + url));
+        return;
+      }
+      resolve(res);
+    }).on('error', reject);
+  });
+}
+
+async function main() {
+  var arch = parseArgs();
+  var destDir = path.join(VENDOR_NODE, arch);
+  var destFile = path.join(destDir, 'node');
+
+  console.log('Snip Node.js Downloader');
+  console.log('=======================');
+  console.log('  Node.js version: v' + NODE_VERSION);
+  console.log('  Architecture:    ' + arch);
+  console.log('  Destination:     vendor/node/' + arch + '/node');
+  console.log('');
+
+  // Check if already downloaded
+  if (fs.existsSync(destFile)) {
+    try {
+      var version = execSync('"' + destFile + '" --version', { encoding: 'utf8' }).trim();
+      if (version === 'v' + NODE_VERSION) {
+        console.log('==> Already downloaded: ' + version);
+        console.log('    Size: ' + formatBytes(fs.statSync(destFile).size));
+        return;
+      }
+      console.log('==> Existing binary is ' + version + ', need v' + NODE_VERSION + ' — re-downloading');
+    } catch (_) {
+      console.log('==> Existing binary is invalid — re-downloading');
+    }
+  }
+
+  // Download tarball
+  var tarballName = 'node-v' + NODE_VERSION + '-darwin-' + arch + '.tar.gz';
+  var url = 'https://nodejs.org/dist/v' + NODE_VERSION + '/' + tarballName;
+  console.log('==> Downloading ' + tarballName + '...');
+
+  var tmpDir = path.join(VENDOR_NODE, '.tmp-' + arch);
+  var tmpTarball = path.join(tmpDir, tarballName);
+
+  fs.mkdirSync(tmpDir, { recursive: true });
+
+  // Stream download to temp file
+  var res = await httpsGet(url);
+  var totalBytes = parseInt(res.headers['content-length'], 10) || 0;
+  var downloaded = 0;
+  var lastPercent = -1;
+
+  await new Promise(function (resolve, reject) {
+    var file = fs.createWriteStream(tmpTarball);
+    res.on('data', function (chunk) {
+      downloaded += chunk.length;
+      if (totalBytes > 0) {
+        var percent = Math.floor((downloaded / totalBytes) * 100);
+        if (percent !== lastPercent && percent % 10 === 0) {
+          lastPercent = percent;
+          process.stdout.write('    ' + percent + '% (' + formatBytes(downloaded) + '/' + formatBytes(totalBytes) + ')\n');
+        }
+      }
+    });
+    res.pipe(file);
+    file.on('finish', function () { file.close(resolve); });
+    file.on('error', reject);
+    res.on('error', reject);
+  });
+
+  console.log('    Downloaded: ' + formatBytes(downloaded));
+
+  // Extract only bin/node from tarball
+  console.log('==> Extracting bin/node...');
+  fs.mkdirSync(destDir, { recursive: true });
+
+  var stripPrefix = 'node-v' + NODE_VERSION + '-darwin-' + arch + '/bin/node';
+  execSync(
+    'tar -xzf "' + tmpTarball + '" -C "' + destDir + '" --strip-components=2 "' + stripPrefix + '"',
+    { stdio: 'inherit' }
+  );
+
+  // Make executable
+  fs.chmodSync(destFile, 0o755);
+
+  // Verify
+  var ver = execSync('"' + destFile + '" --version', { encoding: 'utf8' }).trim();
+  var size = fs.statSync(destFile).size;
+  console.log('==> Extracted: ' + ver + ' (' + formatBytes(size) + ')');
+
+  // Clean up temp
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+
+  console.log('\n==> Done! Bundled Node.js binary ready at vendor/node/' + arch + '/node');
+}
+
+main().catch(function (err) {
+  console.error('\nFailed:', err.message);
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/src/main/segmentation/segmentation.js
+++ b/src/main/segmentation/segmentation.js
@@ -15,13 +15,22 @@ const pendingRequests = new Map();
 let resolvedNodePath = null;
 
 /**
- * Find the system Node.js binary. Searches NVM, common paths, PATH, and FNM.
+ * Find a Node.js binary. Checks bundled binary first, then system installs
+ * (NVM, common paths, PATH, FNM).
  */
 function findNodeBinary() {
   if (resolvedNodePath) return resolvedNodePath;
 
   const candidates = [];
 
+  // 1. Bundled Node.js (packaged app)
+  if (process.resourcesPath) {
+    candidates.push(path.join(process.resourcesPath, 'node', 'node'));
+  }
+  // 2. Bundled Node.js (development)
+  candidates.push(path.join(__dirname, '..', '..', '..', 'vendor', 'node', process.arch, 'node'));
+
+  // 3. System Node.js installs
   const nvmDir = path.join(os.homedir(), '.nvm', 'versions', 'node');
   try {
     const versions = fs.readdirSync(nvmDir).sort();


### PR DESCRIPTION
## Summary

- **Bundles a standalone Node.js 22 LTS binary** (~100MB) into the packaged app so the SAM segmentation tool works without requiring users to install developer tools
- **Drops x64/Intel build support** — arm64 (Apple Silicon) only going forward
- **Updates `findNodeBinary()` priority**: packaged app bundle → dev vendor → system Node.js fallback

## Changes

| File | What |
|------|------|
| `scripts/download-node.js` | New script to download Node.js binary to `vendor/node/{arch}/` |
| `scripts/afterPack.js` | Copies bundled Node binary into `Resources/node/node`, pre-signs it |
| `src/main/segmentation/segmentation.js` | `findNodeBinary()` checks bundled binary first |
| `electron-builder.yml` | Remove x64 from arch list |
| `package.json` | Add `download-node` script, remove `build:x64` |
| `.github/workflows/release.yml` | Remove matrix strategy, add download-node step, simplify Homebrew cask |
| `scripts/build-signed.sh` | Hardcode arm64, remove `--arch` flag |
| `.gitignore` | Add `vendor/node/` |
| `docs/ARCHITECTURE.md` | Update directory tree and SAM docs |
| `docs/DEVOPS.md` | Update scripts table, build pipeline, troubleshooting |
| `README.md` | Update to "Apple Silicon only" |

## Validation

- `findNodeBinary()` resolves to `vendor/node/arm64/node` (v22.14.0) in dev
- `npm run build` produces arm64-only DMG (no x64 build)
- Bundled binary lands at `Contents/Resources/node/node` (103MB, Mach-O arm64)
- Binary is pre-signed with Developer ID certificate
- `checkSupport()` returns `{ supported: true }`
- Full audit confirmed zero remaining x64/Intel references in source code

## Test plan

- [x] `npm run build` succeeds (arm64 only, no x64)
- [x] Bundled node binary exists at `dist/mac-arm64/Snip.app/Contents/Resources/node/node`
- [x] Bundled binary runs: `v22.14.0`, Mach-O arm64, code-signed
- [x] `checkSupport()` returns supported
- [ ] Run packaged app, use segment tool to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)