### PR TITLE
permissions check on first startup

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -236,6 +236,9 @@ The preload script (`preload.js`) exposes `window.snip` with these methods:
 
 | Method | Direction | Purpose |
 |--------|-----------|---------|
+| `getScreenPermission()` | R -> M | Check Screen Recording permission status (`granted`, `denied`, `not-determined`) |
+| `requestScreenPermission()` | R -> M | Trigger macOS native Screen Recording prompt via lightweight `desktopCapturer.getSources()` call; returns new status |
+| `restartApp()` | R -> M | Relaunch and exit the app (used after granting Screen Recording permission) |
 | `getAiEnabled()` / `setAiEnabled(val)` | R -> M | AI opt-in flag (`true`, `false`, or `undefined` on first launch) |
 | `getOllamaConfig()` / `setOllamaConfig(cfg)` | R -> M | Ollama model/URL settings |
 | `getOllamaStatus()` | R -> M | Server running? Model ready? Pull progress? |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -113,7 +113,7 @@ Power users on macOS who take 5-50 screenshots per day: developers, designers, P
 ## Product Principles
 
 1. **Clipboard-first**: Most users want the screenshot on their clipboard immediately. Saving to disk is secondary.
-2. **Zero-config by default**: In-app setup wizard guides Ollama install and model download on first launch. Works without AI if user skips setup.
+2. **Zero-config by default**: On first launch, Snip proactively requests Screen Recording permission (with restart if granted), then guides Ollama install and model download. Works without AI if user skips setup.
 3. **AI is optional**: Users choose during onboarding whether to enable AI. The app works fully without it — capture, annotate, save, and browse all function normally. Only smart naming, tagging, and organization require AI. Users who opted out can enable AI later from Settings.
 4. **Non-intrusive**: Tray-only, no Dock icon, no Space switching, hides during capture.
 5. **AI is invisible labor**: Users don't "invoke AI" — it just happens in the background after save.

--- a/docs/USER_FLOWS.md
+++ b/docs/USER_FLOWS.md
@@ -18,7 +18,8 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 | 2 | -- | No Dock icon visible (`app.dock.hide()` in dev, `LSUIElement: true` in production) |
 | 3 | -- | `~/Documents/snip/screenshots/` directory created automatically |
 | 4 | -- | Config file created at `~/Library/Application Support/snip/snip-config.json` with default categories |
-| 5 | -- | Home window opens with Gallery page showing "No screenshots yet" empty state |
+| 5 | -- | Home window opens; if first launch and Screen Recording not granted, permission view shown first (see §8.0) |
+| 5a | -- | If permission granted (or skipped), shows AI choice view (see §8.1) or Gallery page |
 | 6 | -- | SAM segmentation model begins loading in background (logged: `[Segmentation Worker] Loading SlimSAM model...`) |
 | 7 | -- | File watcher starts monitoring screenshots directory (logged: `[Organizer] Watching: ...`) |
 | 8 | -- | Ollama managed process starts: `findOllamaBinary()` locates CLI binary, `findFreePort()` gets a dynamic port, spawns `ollama serve` |
@@ -604,9 +605,47 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 
 ## 8. Settings
 
+### 8.0 Screen Recording Permission
+
+On first launch, Snip checks Screen Recording permission **before** showing the AI choice. Since granting permission requires an app restart, this must come first.
+
+**First Launch — Permission not granted:**
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | App launches, `aiEnabled` not set in config | Permission check via `systemPreferences.getMediaAccessStatus('screen')` |
+| 2 | Status is `not-determined` | Overlay shows Screen Recording view with **"Allow"** button |
+| 3 | Click "Allow" (or press Enter) | Triggers `desktopCapturer.getSources()` → macOS shows native permission dialog |
+| 4a | User allows | **"Restart Snip"** button shown with hint "Restart is needed for Screen Recording to take effect." |
+| 4b | User denies | Switches to denied state: **"Open System Settings"** + **"Restart Snip"** buttons + hint |
+| 5 | Click "Restart Snip" | App relaunches via `app.relaunch(); app.exit(0)` |
+| 6 | After restart, permission = `granted` | Permission view skipped, proceeds to AI Choice (§8.1) |
+
+**First Launch — Permission already granted (e.g. MDM pre-configured):**
+
+| Condition | Expected Behavior |
+|-----------|-------------------|
+| `getMediaAccessStatus('screen')` returns `granted` | Permission view skipped entirely, goes straight to AI Choice (§8.1) |
+
+**Denied state:**
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Permission status is `denied` | Shows "Open System Settings" + "Restart Snip" buttons |
+| 2 | Click "Open System Settings" | Opens `x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture` |
+| 3 | User enables Snip in System Settings, clicks "Restart Snip" | App relaunches → permission granted → view skipped |
+| 4 | If still denied after restart | Same permission view shown again |
+
+**Skip (Esc):**
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Press Esc or click "Skip for now" | Overlay dismissed entirely |
+| 2 | User tries to capture | Existing reactive dialog in `capturer.js` handles permission (§2.6) |
+
 ### 8.1 AI Choice Screen
 
-On first launch, the app presents an AI choice screen before any Ollama setup. The user's decision is persisted as `aiEnabled` in the config file.
+On first launch (after Screen Recording permission is handled), the app presents an AI choice screen before any Ollama setup. The user's decision is persisted as `aiEnabled` in the config file.
 
 **First Launch (aiEnabled = undefined):**
 
@@ -647,7 +686,7 @@ On first launch, the app presents an AI choice screen before any Ollama setup. T
 
 The setup wizard appears as a **full-window inline overlay** inside the home window (not a separate popup). It auto-shows on first launch if the user chose "Set up AI" (aiEnabled = true) and Ollama is not fully ready, and can be reopened from the Settings "Set up" button.
 
-**Overlay structure:** Four views — AI Choice (first launch only), Steps (install/running/model), Welcome, Failed. Only one visible at a time. Step cards show numbered indicators (pending -> active -> done with checkmark).
+**Overlay structure:** Five views — Permission (first launch, if not granted), AI Choice (first launch only), Steps (install/running/model), Welcome, Failed. Only one visible at a time. Step cards show numbered indicators (pending -> active -> done with checkmark).
 
 | Step | Action | Expected Result |
 |------|--------|-----------------|

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -1,4 +1,4 @@
-const { ipcMain, clipboard, nativeImage, app, Notification, shell, BrowserWindow } = require('electron');
+const { ipcMain, clipboard, nativeImage, app, Notification, shell, BrowserWindow, systemPreferences, desktopCapturer } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const {
@@ -85,6 +85,23 @@ function registerIpcHandlers(getOverlayWindow, createEditorWindowFn) {
       'Courier New', 'Georgia', 'Times New Roman', 'Verdana',
       'Comic Sans MS', 'Impact', 'Futura', 'Avenir'
     ];
+  });
+
+  // Screen recording permission
+  ipcMain.handle('get-screen-permission', async () => {
+    return systemPreferences.getMediaAccessStatus('screen');
+  });
+
+  ipcMain.handle('request-screen-permission', async () => {
+    try {
+      await desktopCapturer.getSources({ types: ['screen'], thumbnailSize: { width: 1, height: 1 } });
+    } catch (e) { console.log('[Snip] Screen permission probe error (expected):', e.message); }
+    return systemPreferences.getMediaAccessStatus('screen');
+  });
+
+  ipcMain.handle('restart-app', () => {
+    app.relaunch();
+    app.exit(0);
   });
 
   // AI preference

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -15,6 +15,11 @@ contextBridge.exposeInMainWorld('snip', {
   getEditorImage: () => ipcRenderer.invoke('get-editor-image'),
   closeEditor: () => ipcRenderer.send('close-editor'),
 
+  // Screen recording permission
+  getScreenPermission: () => ipcRenderer.invoke('get-screen-permission'),
+  requestScreenPermission: () => ipcRenderer.invoke('request-screen-permission'),
+  restartApp: () => ipcRenderer.invoke('restart-app'),
+
   // AI preference
   getAiEnabled: () => ipcRenderer.invoke('get-ai-enabled'),
   setAiEnabled: (enabled) => ipcRenderer.invoke('set-ai-enabled', enabled),

--- a/src/renderer/home.css
+++ b/src/renderer/home.css
@@ -1419,6 +1419,22 @@ kbd {
   border-color: var(--text-muted);
 }
 
+/* Permission buttons container */
+.setup-permission-btns {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.setup-permission-btns > div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+
 /* AI choice buttons container */
 .setup-ai-choice-btns {
   display: flex;

--- a/src/renderer/home.html
+++ b/src/renderer/home.html
@@ -340,6 +340,43 @@
   <div id="setup-overlay" class="setup-overlay hidden">
     <div id="setup-sparkles" class="setup-sparkles"></div>
 
+    <!-- Screen Recording permission view -->
+    <div id="setup-permission-view" class="setup-view hidden">
+      <div class="setup-header">
+        <div class="setup-header-icon">
+          <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+            <rect x="8" y="10" width="32" height="22" rx="3" stroke="var(--accent)" stroke-width="2.5" fill="none"/>
+            <path d="M8 28h32" stroke="var(--accent)" stroke-width="2" opacity="0.4"/>
+            <rect x="18" y="32" width="12" height="2" rx="1" fill="var(--accent)" opacity="0.6"/>
+            <rect x="14" y="35" width="20" height="2" rx="1" fill="var(--accent)" opacity="0.4"/>
+            <circle cx="36" cy="14" r="5" fill="var(--accent)" opacity="0.25"/>
+            <path d="M34.5 14l1 1 2.5-2.5" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </div>
+        <h2>Screen Recording</h2>
+        <p id="setup-perm-desc">Snip needs Screen Recording access to capture your screen.</p>
+      </div>
+      <div class="setup-permission-btns">
+        <button id="setup-perm-allow-btn" class="setup-btn-icon setup-btn-glow">
+          Allow <kbd class="setup-kbd">Enter</kbd>
+        </button>
+        <div id="setup-perm-restart" class="hidden">
+          <button id="setup-perm-restart-btn" class="setup-btn-icon setup-btn-glow">
+            Restart Snip <kbd class="setup-kbd">Enter</kbd>
+          </button>
+        </div>
+        <div id="setup-perm-denied" class="hidden">
+          <button id="setup-perm-settings-btn" class="setup-btn-icon setup-btn-glow">
+            Open System Settings <kbd class="setup-kbd">Enter</kbd>
+          </button>
+          <button id="setup-perm-restart-btn2" class="setup-btn-icon">
+            Restart Snip
+          </button>
+        </div>
+      </div>
+      <button id="setup-perm-skip-btn" class="setup-btn-skip">Skip for now <kbd class="setup-kbd">Esc</kbd></button>
+    </div>
+
     <!-- AI choice view (first-launch opt-in/out) -->
     <div id="setup-ai-choice-view" class="setup-view hidden">
       <div class="setup-header">

--- a/src/renderer/home.js
+++ b/src/renderer/home.js
@@ -916,6 +916,27 @@
       hideSetupOverlay();
     });
 
+    // Permission view buttons
+    var permAllowBtn = document.getElementById('setup-perm-allow-btn');
+    var permRestartDiv = document.getElementById('setup-perm-restart');
+    var permDeniedDiv = document.getElementById('setup-perm-denied');
+    var permSettingsBtn = document.getElementById('setup-perm-settings-btn');
+    var permRestartBtn = document.getElementById('setup-perm-restart-btn');
+    var permRestartBtn2 = document.getElementById('setup-perm-restart-btn2');
+    var permSkipBtn = document.getElementById('setup-perm-skip-btn');
+
+    permAllowBtn.addEventListener('click', handlePermissionAllow);
+
+    permSettingsBtn.addEventListener('click', function() {
+      window.snip.openExternalUrl('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture');
+    });
+
+    var handleRestart = function() { window.snip.restartApp(); };
+    permRestartBtn.addEventListener('click', handleRestart);
+    permRestartBtn2.addEventListener('click', handleRestart);
+
+    permSkipBtn.addEventListener('click', skipPermissionView);
+
     // Action buttons — both primary and retry share the same handler
     var installAction = function() { startSetupAction('install', installBtn, skipBtn, window.snip.installOllama); };
     var modelAction = function() { startSetupAction('model', modelBtn, skipBtn, window.snip.pullOllamaModel); };
@@ -934,6 +955,23 @@
     // Keyboard shortcuts for setup overlay
     document.addEventListener('keydown', function(e) {
       if (overlay.classList.contains('hidden')) return;
+
+      // Permission screen — Enter to Allow (or Settings if denied), Esc to skip
+      var permView = document.getElementById('setup-permission-view');
+      if (permView && !permView.classList.contains('hidden')) {
+        if (e.key === 'Escape') { skipPermissionView(); return; }
+        if (e.key === 'Enter') {
+          if (!permAllowBtn.classList.contains('hidden')) {
+            permAllowBtn.click();
+          } else if (!permRestartDiv.classList.contains('hidden')) {
+            permRestartBtn.click();
+          } else if (!permDeniedDiv.classList.contains('hidden')) {
+            permSettingsBtn.click();
+          }
+          return;
+        }
+        return;
+      }
 
       // AI choice screen — Y to enable, N to skip
       var aiChoiceView = document.getElementById('setup-ai-choice-view');
@@ -1025,16 +1063,84 @@
     // Sync toggle to current state
     updateAiSettingsVisibility(aiEnabled === true ? true : false);
 
-    // First launch — show AI choice screen
+    // First launch — check permission first, then AI choice
     if (aiEnabled === undefined || aiEnabled === null) {
+      var permStatus = await window.snip.getScreenPermission();
       document.getElementById('setup-overlay').classList.remove('hidden');
-      showSetupView('ai-choice');
+      if (permStatus !== 'granted') {
+        showSetupView('permission');
+        applyPermissionState(permStatus);
+      } else {
+        showSetupView('ai-choice');
+      }
       return;
     }
 
     // AI disabled or already enabled — no overlay on launch.
     // User can manage setup from Settings if needed.
     return;
+  }
+
+  var PERM_DESC = {
+    'default': 'Snip needs Screen Recording access to capture your screen.',
+    'restart': 'Snip needs Screen Recording access to capture your screen.',
+    'denied': 'Snip needs Screen Recording access to capture your screen.'
+  };
+  var PERM_DESC_SUB = {
+    'restart': 'Restart is needed for the permission to take effect.',
+    'denied': 'Enable Snip in System Settings, then restart.'
+  };
+
+  function setPermDesc(key) {
+    var desc = document.getElementById('setup-perm-desc');
+    desc.textContent = '';
+    desc.appendChild(document.createTextNode(PERM_DESC[key]));
+    if (PERM_DESC_SUB[key]) {
+      desc.appendChild(document.createElement('br'));
+      desc.appendChild(document.createTextNode(PERM_DESC_SUB[key]));
+    }
+  }
+
+  function applyPermissionState(status) {
+    var allowBtn = document.getElementById('setup-perm-allow-btn');
+    var restartDiv = document.getElementById('setup-perm-restart');
+    var deniedDiv = document.getElementById('setup-perm-denied');
+
+    allowBtn.classList.add('hidden');
+    restartDiv.classList.add('hidden');
+    deniedDiv.classList.add('hidden');
+
+    if (status === 'denied') {
+      setPermDesc('denied');
+      deniedDiv.classList.remove('hidden');
+    } else {
+      // not-determined or any other state — show Allow button
+      setPermDesc('default');
+      allowBtn.classList.remove('hidden');
+    }
+  }
+
+  async function handlePermissionAllow() {
+    var allowBtn = document.getElementById('setup-perm-allow-btn');
+    allowBtn.disabled = true;
+    var result = await window.snip.requestScreenPermission();
+    allowBtn.disabled = false;
+
+    if (result === 'granted') {
+      // Permission granted but needs restart to take effect
+      allowBtn.classList.add('hidden');
+      document.getElementById('setup-perm-denied').classList.add('hidden');
+      document.getElementById('setup-perm-restart').classList.remove('hidden');
+      setPermDesc('restart');
+    } else {
+      // User denied — show Settings + Restart
+      applyPermissionState('denied');
+    }
+  }
+
+  function skipPermissionView() {
+    // Dismiss overlay entirely — reactive dialog in capturer.js handles permission later
+    hideSetupOverlay();
   }
 
   async function showSetupOverlay() {
@@ -1072,7 +1178,7 @@
   }
 
   function showSetupView(viewName) {
-    var views = { 'ai-choice': 'setup-ai-choice-view', steps: 'setup-steps-view', welcome: 'setup-welcome-view', failed: 'setup-failed-view' };
+    var views = { permission: 'setup-permission-view', 'ai-choice': 'setup-ai-choice-view', steps: 'setup-steps-view', welcome: 'setup-welcome-view', failed: 'setup-failed-view' };
     var keys = Object.keys(views);
     for (var i = 0; i < keys.length; i++) {
       document.getElementById(views[keys[i]]).classList.add('hidden');
@@ -1090,6 +1196,9 @@
       stopSparkles();
     } else if (viewName === 'ai-choice') {
       document.getElementById(views['ai-choice']).classList.remove('hidden');
+      startSparkles();
+    } else if (viewName === 'permission') {
+      document.getElementById(views.permission).classList.remove('hidden');
       startSparkles();
     } else {
       document.getElementById(views.steps).classList.remove('hidden');


### PR DESCRIPTION
<img width="906" height="623" alt="Screenshot 2026-03-03 at 6 10 43 PM" src="https://github.com/user-attachments/assets/64f20370-fcd9-49a5-b9d6-91f6c4c3e38b" />

Flow 1: Happy path (first launch, user grants)

  1. App launches, no config → permission view appears
  2. "Snip needs Screen Recording access to capture your screen."
  3. User clicks Allow → macOS native permission dialog appears
  4. User grants → description updates: "...Restart is needed for the permission to take effect."
  5. User clicks Restart Snip → app relaunches
  6. After restart, permission is granted → permission view skipped → AI Choice shown

  Flow 2: User denies

  1. App launches → permission view with Allow button
  2. User clicks Allow → macOS native dialog → user denies
  3. Description updates: "...Enable Snip in System Settings, then restart."
  4. Open System Settings + Restart Snip buttons shown
  5. User opens System Settings, toggles Snip on, comes back
  6. User clicks Restart Snip → app relaunches → permission granted → AI Choice shown

  Flow 3: Previously denied (returns to permission view after restart)

  1. App launches, config doesn't exist, permission already denied (denied in a previous attempt)
  2. Permission view shows immediately with Open System Settings + Restart Snip
  3. Same as Flow 2 steps 5-6

  Flow 4: Skip

  1. App launches → permission view appears
  2. User presses Esc or clicks Skip for now
  3. Overlay dismissed entirely — app is usable
  4. When user tries to capture (Cmd+Shift+2), existing reactive dialog in capturer.js handles the
  permission prompt

  Flow 5: Permission already granted (MDM, or returning after successful restart)

  1. App launches, no config, but permission is already granted
  2. Permission view skipped entirely → AI Choice shown immediately

  Flow 6: Returning user (config exists)

  1. App launches, config exists (aiEnabled is true or false)
  2. No setup overlay shown at all — permission handled reactively if needed