### PR TITLE
Instant capture UX: no Enter needed, rename to Snip and Annotate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ These are non-negotiable rules. Violating them causes crashes or broken UX:
 - Main process uses standard CommonJS `require()`.
 
 ### Naming
-- UI text says **"snip"** not "screenshot". The capture action is **"Snip It"**.
+- UI text says **"snip"** not "screenshot". The capture action is **"Snip and Annotate"**.
 
 ### Purple Brand
 - Accent color is **purple/violet**. Never blue. See `docs/DESIGN.md` for exact values per theme.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,7 +203,7 @@ Only app-saved files trigger AI processing. The `pendingFiles` Set in `watcher.j
 
 ### Naming
 - UI text says "snip" not "screenshot"
-- The capture action is "Snip It"
+- The capture action is "Snip and Annotate"
 - Variables use camelCase
 - CSS classes use kebab-case
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -32,9 +32,9 @@ Power users on macOS who take 5-50 screenshots per day: developers, designers, P
 ## Feature Set
 
 ### Capture
-- **Global shortcut** (Cmd+Shift+2): Fullscreen overlay, click a window to snap-select it, or drag to select a custom region, Enter to crop
+- **Global shortcut** (Cmd+Shift+2): Fullscreen overlay, click a window to snap-select it, or drag to select a custom region — completes immediately on mouse-up
 - **Quick Snip** (Cmd+Shift+1): Same overlay with window/region selection, copies result directly to clipboard without opening the annotation editor
-- **Full-screen capture**: Press Enter without dragging
+- **Full-screen capture**: Press Enter without selecting
 - Works across macOS Spaces without switching desktops
 - Home window hides during capture to stay out of the way
 
@@ -96,7 +96,7 @@ Power users on macOS who take 5-50 screenshots per day: developers, designers, P
 - Full keyboard shortcuts reference table
 
 ### Tray Menu
-- Snip It, Quick Snip, Search Snips, Open Snip, Theme submenu (Dark / Light / Glass), Quit Snip
+- Quick Snip, Snip and Annotate, Search Snips, Open Snip, Theme submenu (Dark / Light / Glass), Quit Snip
 
 ---
 
@@ -105,7 +105,7 @@ Power users on macOS who take 5-50 screenshots per day: developers, designers, P
 | Term | Meaning |
 |------|---------|
 | **Snip** | A screenshot (never say "screenshot" in the UI) |
-| **Snip It** | The capture action (menu item and tray label) |
+| **Snip and Annotate** | The capture action that opens the annotation editor (menu item and tray label) |
 | **Category** | AI-assigned folder: code, chat, web, design, documents, terminal, personal, fun, other |
 | **Tag** | AI-assigned keyword for search/filtering |
 | **Glass** | The translucent Liquid Glass theme on macOS 26+ |

--- a/docs/USER_FLOWS.md
+++ b/docs/USER_FLOWS.md
@@ -78,12 +78,10 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 | 2 | -- | Display under the cursor is captured via `desktopCapturer.getSources()` |
 | 3 | -- | Fullscreen transparent overlay appears on that display |
 | 4 | -- | Overlay covers entire display including menu bar |
-| 5 | -- | Cursor becomes crosshair, hint text visible: "Click a window to select it, or drag to select an area" |
-| 5a | Move cursor over a window | Window highlighted with accent border and owner/title label |
-| 6a | Click on a highlighted window | Window bounds become the selection (snap-select) |
-| 6b | Drag to select a rectangular region | Selection box appears with dashed border |
-| 7 | (Optional) Drag inside selection to reposition | Selection moves without resizing |
-| 8 | Press Enter | Overlay closes, editor window opens with cropped image |
+| 5 | -- | Cursor becomes crosshair, hint text visible: "Click to screenshot the selected window · Drag to capture an area · Esc to cancel" |
+| 5a | Move cursor over a window | Window highlighted with accent border and owner/title label (only windows with ≥50×50 visible area shown) |
+| 6a | Click on a highlighted window | Window captured immediately, overlay closes, editor opens with cropped image |
+| 6b | Drag to select a rectangular region | On mouse-up, overlay closes and editor opens with cropped image |
 | 9 | -- | Editor window is centered on screen, min width 900px |
 | 10 | -- | Toolbar visible at top with all tools |
 
@@ -92,7 +90,7 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 | Step | Action | Expected Result |
 |------|--------|-----------------|
 | 1 | Press Cmd+Shift+2 | Overlay appears |
-| 2 | Press Enter immediately (no drag) | Editor opens with full-screen capture |
+| 2 | Press Enter (no drag) | Editor opens with full-screen capture |
 
 ### 2.3 Cancel Capture
 
@@ -100,6 +98,7 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 |------|--------|-----------------|
 | 1 | Press Cmd+Shift+2 | Overlay appears |
 | 2 | Press Escape | Overlay closes, home window re-shows |
+| 2a | (Alt) Switch away (Cmd+Tab, click another app) | Overlay auto-dismisses — stale screenshot is discarded |
 
 ### 2.4 Capture While Editor Is Open
 
@@ -148,8 +147,7 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 | Step | Action | Expected Result |
 |------|--------|-----------------|
 | 1 | Press Cmd+Shift+1 (default) | Same capture overlay appears with window highlight and region selection |
-| 2 | Click a window or drag a region | Selection made (same as regular capture flow §2.1) |
-| 3 | Press Enter | Cropped image copied directly to clipboard — no annotation editor opens |
+| 2 | Click a window or drag a region | Cropped image copied directly to clipboard on mouse-up — no annotation editor opens |
 
 **Edge cases:**
 - Esc cancels the selection and closes the overlay (same as regular capture)
@@ -889,7 +887,7 @@ The Shortcuts section shows two groups: **configurable shortcuts** (2 global sho
 | Action | Expected Result |
 |--------|-----------------|
 | Click tray icon | Tray menu appears |
-| "Snip It" menu item | Triggers capture (same as Cmd+Shift+2) |
+| "Snip and Annotate" menu item | Triggers capture (same as Cmd+Shift+2) |
 | "Quick Snip" menu item | Opens capture overlay in quick-snip mode — select & copy to clipboard (same as Cmd+Shift+1) |
 | "Search Snips" menu item | Opens search page (same as Cmd+Shift+S) |
 | "Open Snip" menu item | Opens/focuses home window |

--- a/site/index.html
+++ b/site/index.html
@@ -249,7 +249,7 @@
           <div class="step-number">1</div>
           <div class="step-content">
             <h3>Capture</h3>
-            <p><kbd>Cmd+Shift+2</kbd> opens a fullscreen overlay. Drag to select any region, or press Enter for full screen.</p>
+            <p><kbd>Cmd+Shift+2</kbd> opens a fullscreen overlay. Click a window or drag a region — capture completes instantly.</p>
           </div>
         </div>
         <div class="step">

--- a/src/main/capturer.js
+++ b/src/main/capturer.js
@@ -120,6 +120,11 @@ async function captureScreen(createOverlayFn, getOverlayFn, opts) {
     overlayWindow.setAlwaysOnTop(true, 'screen-saver');
     overlayWindow.show();
     overlayWindow.focus();
+    // If the user switches away (Cmd+Tab, click another app), cancel the capture.
+    // The stale screenshot would be confusing; they can re-trigger the shortcut.
+    overlayWindow.on('blur', () => {
+      if (!overlayWindow.isDestroyed()) overlayWindow.destroy();
+    });
     // Force position to cover full screen including menu bar
     // (macOS may push the window below menu bar on show)
     const bounds = cursorDisplay.bounds;

--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -15,12 +15,12 @@ function buildTrayMenu() {
 
   const template = [
     {
-      label: 'Snip It',
-      click: trayCallbacks.capture
-    },
-    {
       label: 'Quick Snip',
       click: trayCallbacks.quickSnip
+    },
+    {
+      label: 'Snip and Annotate',
+      click: trayCallbacks.capture
     },
     {
       label: 'Search Snips',

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -22,7 +22,19 @@
     const winOffsetX = (window.screenX || 0) - displayOrigin.x;
     const winOffsetY = (window.screenY || 0) - displayOrigin.y;
     windowList = (data.windowList || []).map(function(w) {
-      return { x: w.x - winOffsetX, y: w.y - winOffsetY, width: w.width, height: w.height, owner: w.owner, name: w.name };
+      // Convert to overlay-viewport-relative coords, then clip to viewport bounds.
+      // Windows partially off-screen (e.g. spanning two displays, or behind the menu bar)
+      // are clipped so hover detection and snap use only the visible portion.
+      const wx = w.x - winOffsetX;
+      const wy = w.y - winOffsetY;
+      const clipX = Math.max(0, wx);
+      const clipY = Math.max(0, wy);
+      const clipX2 = Math.min(width, wx + w.width);
+      const clipY2 = Math.min(height, wy + w.height);
+      return { x: clipX, y: clipY, width: clipX2 - clipX, height: clipY2 - clipY, owner: w.owner, name: w.name };
+    }).filter(function(w) {
+      // Drop windows with less than 50×50 visible area in the viewport
+      return w.width > 50 && w.height > 50;
     });
 
     // Reset previous selection

--- a/src/renderer/home.js
+++ b/src/renderer/home.js
@@ -636,8 +636,8 @@
 
   // ── Keyboard Shortcuts settings ──
   var SHORTCUT_DEFINITIONS = [
-    { action: 'capture', name: 'Snip It', context: 'Global', configurable: true },
     { action: 'quick-snip', name: 'Quick Snip', context: 'Global', configurable: true },
+    { action: 'capture', name: 'Snip and Annotate', context: 'Global', configurable: true },
     { action: 'search', name: 'Search snips', context: 'Global', configurable: true },
     { action: null, name: 'Select tool', context: 'Annotation', configurable: false, display: 'V' },
     { action: null, name: 'Rectangle tool', context: 'Annotation', configurable: false, display: 'R' },

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <canvas id="selection-overlay" class="hidden"></canvas>
-  <div id="selection-hint" class="hidden">Click a window to select it, or drag to select an area. Enter to confirm, Esc to cancel.</div>
+  <div id="selection-hint" class="hidden">Click to screenshot the selected window · Drag to capture an area · Esc to cancel</div>
 
   <script src="tools/selection.js"></script>
   <script src="app.js"></script>

--- a/src/renderer/tools/selection.js
+++ b/src/renderer/tools/selection.js
@@ -5,7 +5,7 @@ const SelectionTool = (() => {
     return getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#8B5CF6';
   }
 
-  // States: 'idle' | 'drawing' | 'selected' | 'moving'
+  // States: 'idle' | 'drawing'
   function attach(canvasEl, fullWidth, fullHeight, onComplete, onCancel, windowList) {
     const overlay = document.getElementById('selection-overlay');
     const ctx = overlay.getContext('2d');
@@ -26,8 +26,6 @@ const SelectionTool = (() => {
     var drawCurrentX = 0, drawCurrentY = 0;
     // Selection rect (finalized)
     var selX = 0, selY = 0, selW = 0, selH = 0;
-    // Moving state
-    var moveOffsetX = 0, moveOffsetY = 0;
     // Window snap state
     var hoveredWindow = null;
     var pendingClick = false;
@@ -57,8 +55,6 @@ const SelectionTool = (() => {
         y = Math.min(drawStartY, drawCurrentY);
         w = Math.abs(drawCurrentX - drawStartX);
         h = Math.abs(drawCurrentY - drawStartY);
-      } else if (state === 'selected' || state === 'moving') {
-        x = selX; y = selY; w = selW; h = selH;
       } else if (state === 'idle' && hoveredWindow) {
         // Highlight the window under cursor
         x = hoveredWindow.x; y = hoveredWindow.y;
@@ -124,34 +120,22 @@ const SelectionTool = (() => {
       }
     }
 
-    function isInsideSelection(mx, my) {
-      return mx >= selX && mx <= selX + selW && my >= selY && my <= selY + selH;
-    }
-
     function onMouseDown(e) {
       var mx = e.clientX, my = e.clientY;
 
-      if (state === 'selected' && isInsideSelection(mx, my)) {
-        // Start moving existing selection
-        state = 'moving';
-        moveOffsetX = mx - selX;
-        moveOffsetY = my - selY;
-        overlay.style.cursor = 'grabbing';
-      } else {
-        // If there's a hovered window, start pending click detection
-        if (state === 'idle' && hoveredWindow) {
-          pendingClick = true;
-          pendingClickX = mx;
-          pendingClickY = my;
-        }
-        // Start new drawing (from idle or replacing existing selection)
-        state = 'drawing';
-        drawStartX = mx;
-        drawStartY = my;
-        drawCurrentX = mx;
-        drawCurrentY = my;
-        overlay.style.cursor = 'crosshair';
+      // If there's a hovered window, start pending click detection
+      if (state === 'idle' && hoveredWindow) {
+        pendingClick = true;
+        pendingClickX = mx;
+        pendingClickY = my;
       }
+      // Start new drawing
+      state = 'drawing';
+      drawStartX = mx;
+      drawStartY = my;
+      drawCurrentX = mx;
+      drawCurrentY = my;
+      overlay.style.cursor = 'crosshair';
       draw();
     }
 
@@ -171,13 +155,6 @@ const SelectionTool = (() => {
         drawCurrentX = mx;
         drawCurrentY = my;
         draw();
-      } else if (state === 'moving') {
-        selX = Math.max(0, Math.min(mx - moveOffsetX, fullWidth - selW));
-        selY = Math.max(0, Math.min(my - moveOffsetY, fullHeight - selH));
-        draw();
-      } else if (state === 'selected') {
-        // Update cursor based on hover
-        overlay.style.cursor = isInsideSelection(mx, my) ? 'grab' : 'crosshair';
       } else if (state === 'idle' && windows.length > 0) {
         // Highlight window under cursor
         var win = findWindowAt(mx, my);
@@ -191,81 +168,57 @@ const SelectionTool = (() => {
     function onMouseUp(e) {
       var mx = e.clientX, my = e.clientY;
 
-      if (state === 'drawing') {
-        // Check for window snap click (small drag = click on window)
-        if (pendingClick && hoveredWindow) {
-          var dx = mx - pendingClickX;
-          var dy = my - pendingClickY;
-          if (Math.sqrt(dx * dx + dy * dy) <= DRAG_THRESHOLD) {
-            // Snap to window bounds
-            selX = hoveredWindow.x;
-            selY = hoveredWindow.y;
-            selW = hoveredWindow.width;
-            selH = hoveredWindow.height;
-            // Clamp to overlay bounds
-            selX = Math.max(0, selX);
-            selY = Math.max(0, selY);
-            selW = Math.min(selW, fullWidth - selX);
-            selH = Math.min(selH, fullHeight - selY);
-            state = 'selected';
-            pendingClick = false;
-            hoveredWindow = null;
-            overlay.style.cursor = isInsideSelection(mx, my) ? 'grab' : 'crosshair';
-            draw();
-            return;
-          }
-        }
-        pendingClick = false;
+      if (state !== 'drawing') return;
 
-        var x = Math.min(drawStartX, drawCurrentX);
-        var y = Math.min(drawStartY, drawCurrentY);
-        var w = Math.abs(drawCurrentX - drawStartX);
-        var h = Math.abs(drawCurrentY - drawStartY);
-
-        if (w > 10 && h > 10) {
-          // Valid selection — enter selected state
-          selX = x; selY = y; selW = w; selH = h;
-          state = 'selected';
+      // Check for window snap click (small drag = click on window)
+      if (pendingClick && hoveredWindow) {
+        var dx = mx - pendingClickX;
+        var dy = my - pendingClickY;
+        if (Math.sqrt(dx * dx + dy * dy) <= DRAG_THRESHOLD) {
+          // Snap to window bounds
+          selX = Math.max(0, hoveredWindow.x);
+          selY = Math.max(0, hoveredWindow.y);
+          selW = Math.min(hoveredWindow.width, fullWidth - selX);
+          selH = Math.min(hoveredWindow.height, fullHeight - selY);
+          pendingClick = false;
           hoveredWindow = null;
-          overlay.style.cursor = isInsideSelection(mx, my) ? 'grab' : 'crosshair';
-        } else {
-          // Too small, reset to idle
-          state = 'idle';
-          overlay.style.cursor = 'crosshair';
+          removeListeners();
+          onComplete({ x: selX, y: selY, width: selW, height: selH });
+          return;
         }
-        draw();
-      } else if (state === 'moving') {
-        state = 'selected';
-        overlay.style.cursor = isInsideSelection(mx, my) ? 'grab' : 'crosshair';
-        draw();
       }
+      pendingClick = false;
+
+      var x = Math.min(drawStartX, drawCurrentX);
+      var y = Math.min(drawStartY, drawCurrentY);
+      var w = Math.abs(drawCurrentX - drawStartX);
+      var h = Math.abs(drawCurrentY - drawStartY);
+
+      if (w > 10 && h > 10) {
+        // Valid selection — complete immediately
+        selX = x; selY = y; selW = w; selH = h;
+        hoveredWindow = null;
+        removeListeners();
+        onComplete({ x: selX, y: selY, width: selW, height: selH });
+        return;
+      } else {
+        // Too small, reset to idle
+        state = 'idle';
+        overlay.style.cursor = 'crosshair';
+      }
+      draw();
     }
 
     function onKeyDown(e) {
       if (e.key === 'Enter') {
         e.preventDefault();
-        if (state === 'selected') {
-          // Confirm the selection
-          removeListeners();
-          onComplete({ x: selX, y: selY, width: selW, height: selH });
-        } else {
-          // No selection — full screen
-          cleanup();
-          onComplete(null);
-        }
+        // No selection — full screen capture
+        cleanup();
+        onComplete(null);
       } else if (e.key === 'Escape') {
         e.preventDefault();
-        if (state === 'selected') {
-          // Clear selection, go back to idle
-          state = 'idle';
-          selX = selY = selW = selH = 0;
-          overlay.style.cursor = 'crosshair';
-          draw();
-        } else {
-          // Cancel entirely
-          cleanup();
-          onCancel();
-        }
+        cleanup();
+        onCancel();
       }
     }
 


### PR DESCRIPTION
## Summary
- **Instant capture**: Window click and area drag both complete immediately on mouse-up — no Enter/Return confirmation step needed
- **Rename**: "Snip It" → "Snip and Annotate", reordered tray menu (Quick Snip first)
- **Viewport clipping**: Window snap targets are clipped to visible viewport bounds; windows with <50×50 visible area are excluded
- **Auto-dismiss on blur**: Overlay closes when user switches away (Cmd+Tab, click another app) to avoid stale screenshots
- **Dead code cleanup**: Removed unused `selected`/`moving` state logic from SelectionTool (~30 lines)

## Test plan
- [ ] Cmd+Shift+1 (Quick Snip): click a window → screenshot copies to clipboard immediately
- [ ] Cmd+Shift+1: drag an area → screenshot copies to clipboard on mouse-up
- [ ] Cmd+Shift+2 (Snip and Annotate): click a window → editor opens immediately
- [ ] Cmd+Shift+2: drag an area → editor opens on mouse-up
- [ ] Esc cancels capture in both modes
- [ ] Enter with no selection still does full-screen capture
- [ ] Cmd+Tab during capture overlay → overlay auto-dismisses
- [ ] Tray menu shows: Quick Snip, Snip and Annotate (in that order)
- [ ] Settings > Keyboard Shortcuts shows updated names and order
- [ ] Window partially off-screen: only visible portion highlights/snaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)