### PR TITLE
Fix tray menu shortcut assignment and quit hang

### DIFF
--- a/scripts/build-signed.sh
+++ b/scripts/build-signed.sh
@@ -68,7 +68,7 @@ cd "$PROJECT_ROOT"
 
 echo ""
 echo "🔨 Building native modules for $TARGET_ARCH..."
-node-gyp rebuild
+npx node-gyp rebuild
 
 echo ""
 echo "🏗️  Building signed DMG ($TARGET_ARCH)..."

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -402,13 +402,12 @@ app.whenReady().then(() => {
   showHomeWindow();
 });
 
-app.on('will-quit', () => {
+app.on('will-quit', (e) => {
+  e.preventDefault();
   unregisterShortcuts();
-  stopOllama();
-
-  // Kill child processes so the app can exit cleanly
   try { require('./segmentation/segmentation').killWorker(); } catch (_) {}
   try { require('./upscaler/upscaler').killWorker(); } catch (_) {}
+  stopOllama().finally(() => app.exit(0));
 });
 
 app.on('window-all-closed', (e) => {

--- a/src/main/tray.js
+++ b/src/main/tray.js
@@ -64,8 +64,8 @@ function buildTrayMenu() {
   ];
 
   // Add accelerators only if valid (avoid crashing on malformed config)
-  if (captureAccel) template[0].accelerator = captureAccel;
-  if (quickSnipAccel) template[1].accelerator = quickSnipAccel;
+  if (quickSnipAccel) template[0].accelerator = quickSnipAccel;
+  if (captureAccel) template[1].accelerator = captureAccel;
   if (searchAccel) template[2].accelerator = searchAccel;
 
   try {


### PR DESCRIPTION
## Summary
- **Tray shortcuts swapped**: Quick Snip was showing Cmd+Shift+2 and Snip and Annotate was showing Cmd+Shift+1 — now correctly reversed to match store defaults
- **Quit hang fixed**: `stopOllama()` was async but not awaited in `will-quit`, causing the tray icon to persist after quitting. Now properly awaited via `e.preventDefault()` + `app.exit(0)`
- **Build script fix**: `node-gyp` → `npx node-gyp` in `build-signed.sh` to fix command-not-found in PATH-limited shells

## Test plan
- [ ] Open tray menu — Quick Snip shows Cmd+Shift+1, Snip and Annotate shows Cmd+Shift+2
- [ ] Both shortcuts trigger the correct capture mode
- [ ] Quit Snip from tray menu — tray icon disappears cleanly without hanging
- [ ] `./scripts/build-signed.sh` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)