### PR TITLE
Add CLI for AI integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,8 @@ These are non-negotiable rules. Violating them causes crashes or broken UX:
 | Extension registry | `src/main/extension-registry.js` |
 | Extensions (bundled) | `src/extensions/` + `extensions.json` |
 | Extensions (user) | `~/Library/Application Support/snip/extensions/` |
-| MCP server | `src/mcp/server.js` |
+| CLI | `src/cli/snip.js` |
+| MCP adapter | `src/mcp/server.js` (wraps CLI) |
 | Extension sandbox | `src/main/extension-sandbox.js` + `extension-sandbox-worker.js` |
 | Ollama manager | `src/main/ollama-manager.js` |
 | Ollama (system) | `/Applications/Ollama.app` or `/usr/local/bin/ollama` (user-installed) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,8 +82,11 @@ src/
     extensions.json            # Registry of active bundled extensions
     EXTENSIONS.md              # Extension developer guide
 
-  mcp/                       # MCP (Model Context Protocol) server
-    server.js                  # Stdio adapter — bridges MCP JSON-RPC to Snip's Unix socket
+  cli/                       # CLI interface (primary tool interface)
+    snip.js                    # CLI binary — connects to Unix socket, JSON/text output
+
+  mcp/                       # MCP adapter (thin wrapper around CLI)
+    server.js                  # Stdio adapter — spawns CLI for tool calls, direct socket for install_extension
 
   renderer/                  # Renderer processes (no modules, globals via IIFEs)
     index.html / app.js      # Capture overlay — fullscreen transparent region selector
@@ -277,7 +280,9 @@ An MCP (Model Context Protocol) server exposes Snip's capabilities to external A
 
 1. **Unix domain socket** (`socket-server.js`) — listens at `~/Library/Application Support/snip/snip.sock` (chmod 600). Accepts newline-delimited JSON messages with `{ id, action, params }`. Registered actions: `search_screenshots`, `list_screenshots`, `get_screenshot`, `transcribe_screenshot`, `organize_screenshot`, `get_categories`, `open_in_snip`, `install_extension`. The `open_in_snip` action opens the editor with an external image, blocks until the user finishes annotating, and returns the edited PNG via a `pendingMcpResolve` promise resolved by the `editor-result` IPC channel.
 
-2. **MCP stdio adapter** (`src/mcp/server.js`) — standalone Node.js process that speaks MCP JSON-RPC 2.0 over stdio and forwards tool calls to the socket. Configure in Claude Desktop:
+2. **Snip CLI** (`src/cli/snip.js`) — primary interface. Commands: `search`, `list`, `get`, `transcribe`, `organize`, `categories`, `open`. Auto-launches Snip if not running. Connects to the socket, prints JSON/text to stdout. AI agents call this via bash.
+
+3. **MCP stdio adapter** (`src/mcp/server.js`) — thin wrapper that spawns the CLI for tool calls. Speaks MCP JSON-RPC 2.0 over stdio. Uses direct socket only for `install_extension` (complex JSON params) and `open_in_snip` with `imageDataURL` (too large for CLI args). Configure in Claude Desktop:
 ```json
 {
   "mcpServers": {
@@ -422,13 +427,20 @@ The preload script (`preload.js`) exposes `window.snip` with these methods:
 | `resetShortcuts()` | R -> M | Deletes all custom shortcuts, restores defaults |
 | `onShortcutsChanged(cb)` | M -> R | Broadcast event when shortcuts change (re-registers global shortcuts) |
 | `getMcpConfig()` | R -> M | Get MCP enabled state + per-category toggles |
-| `setMcpConfig(config)` | R -> M | Update MCP enabled/category state; starts/stops socket server on toggle |
+| `setMcpConfig(config)` | R -> M | Update MCP UI visibility + category toggles (socket always runs) |
 | `getMcpClientConfig()` | R -> M | Get resolved `command`+`args` JSON for MCP client config (dev vs packaged paths) |
 | `onMcpConfigChanged(cb)` | M -> R | Push event when MCP config changes |
 | `sendEditorResult(dataURL)` | R -> M | Send edited image (or null for cancel) back to MCP `open_in_snip` handler |
 | `getUserExtensions()` | R -> M | List user-installed extensions (name, type, permissions) |
 | `removeUserExtension(name)` | R -> M | Remove a user extension (kills sandbox, deletes files) |
 | `installExtensionFromFolder()` | R -> M | Open folder picker, validate, show approval dialog, install |
+| `installCli()` | R -> M | Write shell wrapper to `/usr/local/bin/snip` (or `~/bin/snip`) |
+| `checkCliInstalled()` | R -> M | Check if CLI wrapper exists |
+| `detectAiProviders()` | R -> M | Scan for installed AI tools (Claude Code, Cursor, Windsurf, Cline) |
+| `configureAiProvider(id)` | R -> M | Write Snip rules to a detected AI provider's config |
+| `removeAiProvider(id)` | R -> M | Remove Snip rules from an AI provider's config |
+| `checkAiProviderStatus(id)` | R -> M | Check if Snip rules are configured for a provider |
+| `uninstallCli()` | R -> M | Remove CLI wrapper from all candidate paths |
 
 *(R = Renderer, M = Main)*
 
@@ -513,7 +525,7 @@ The native Liquid Glass layer is always present (macOS 26+). Dark and Light them
 | Field | Type | Description |
 |-------|------|-------------|
 | `aiEnabled` | `boolean \| undefined` | `undefined` on first launch (triggers AI choice screen), `true` if user opted in, `false` if user opted out. When `false`, Ollama is not started and AI organization is skipped entirely. |
-| `mcpEnabled` | `boolean` | Whether the MCP socket server is active. Default `false`. |
+| `mcpEnabled` | `boolean` | Controls MCP config visibility in Settings UI. Socket server always runs. Default `false`. |
 | `mcpCategories` | `object` | Per-category toggles: `{ library, upload, transcribe, organize }`. Each is boolean, all default to `true`. Controls which MCP tools are active. |
 
 | Ollama binary | `/usr/local/bin/ollama`, `/opt/homebrew/bin/ollama`, or `/Applications/Ollama.app/Contents/Resources/ollama` | same (user-installed) |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -67,6 +67,8 @@ extraResources:
     to: "native/window_utils.node"
   - from: "vendor/models"
     to: "models"
+  - from: "src/cli/snip.js"
+    to: "cli/snip.js"
 
 extraMetadata:
   main: src/main/main.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "rixinw",
   "license": "MIT",
   "main": "src/main/main.js",
+  "bin": {
+    "snip": "src/cli/snip.js"
+  },
   "scripts": {
     "start": "electron .",
     "dev": "ELECTRON_ENABLE_LOGGING=1 electron .",

--- a/src/cli/snip.js
+++ b/src/cli/snip.js
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+/**
+ * Snip CLI — command-line interface for Snip.
+ * Connects to the running Snip app via Unix domain socket.
+ * Auto-launches Snip if not running (packaged app only).
+ *
+ * Usage:
+ *   snip search "login form"       Search screenshots
+ *   snip list                      List all screenshots
+ *   snip get <filepath>            Get screenshot metadata
+ *   snip transcribe <filepath>     Extract text (OCR)
+ *   snip organize <filepath>       Queue for AI categorization
+ *   snip categories                List categories
+ *   snip open <filepath>           Open in editor, get annotated result
+ */
+
+var net = require('net');
+var path = require('path');
+var os = require('os');
+var fs = require('fs');
+
+var SOCKET_PATH = process.env.SNIP_SOCKET_PATH || path.join(os.homedir(), 'Library', 'Application Support', 'snip', 'snip.sock');
+
+// ── Parse args ──
+
+var args = process.argv.slice(2);
+var command = args[0];
+var flags = {};
+var positional = [];
+
+for (var i = 1; i < args.length; i++) {
+  if (args[i] === '--json') flags.json = true;
+  else if (args[i] === '--pretty') flags.pretty = true;
+  else if (args[i] === '--help' || args[i] === '-h') flags.help = true;
+  else positional.push(args[i]);
+}
+
+if (!command || command === '--help' || command === '-h' || flags.help) {
+  printHelp();
+  process.exit(0);
+}
+
+// ── Command map ──
+
+var COMMANDS = {
+  search:     { action: 'search_screenshots', paramName: 'query', needsArg: true },
+  list:       { action: 'list_screenshots' },
+  get:        { action: 'get_screenshot', paramName: 'filepath', needsArg: true },
+  transcribe: { action: 'transcribe_screenshot', paramName: 'filepath', needsArg: true },
+  organize:   { action: 'organize_screenshot', paramName: 'filepath', needsArg: true },
+  categories: { action: 'get_categories' },
+  open:       { action: 'open_in_snip', paramName: 'filepath', needsArg: true }
+};
+
+var cmd = COMMANDS[command];
+if (!cmd) {
+  process.stderr.write('Unknown command: ' + command + '\n');
+  printHelp();
+  process.exit(1);
+}
+
+// Validate required arg
+if (cmd.needsArg && positional.length === 0) {
+  process.stderr.write('Missing argument for ' + command + '\n');
+  process.exit(1);
+}
+
+// Build params
+var params = {};
+if (cmd.paramName && positional[0]) {
+  var val = positional[0];
+  if (cmd.paramName === 'filepath') {
+    val = path.resolve(val);
+  }
+  params[cmd.paramName] = val;
+}
+
+// Execute
+callSnip(cmd.action, params, false).then(function (result) {
+  formatOutput(command, result);
+  process.exit(0);
+}).catch(function (err) {
+  process.stderr.write('Error: ' + err.message + '\n');
+  process.exit(1);
+});
+
+// ── Socket connection ──
+
+function callSnip(action, params, isRetry) {
+  return new Promise(function (resolve, reject) {
+    var conn = net.createConnection(SOCKET_PATH);
+    var buffer = '';
+    var id = 'cli-' + Date.now();
+
+    conn.on('connect', function () {
+      var msg = JSON.stringify({ id: id, action: action, params: params || {} }) + '\n';
+      conn.write(msg);
+    });
+
+    conn.on('data', function (chunk) {
+      buffer += chunk.toString();
+      var newlineIdx = buffer.indexOf('\n');
+      if (newlineIdx !== -1) {
+        var line = buffer.slice(0, newlineIdx).trim();
+        conn.end();
+        try {
+          var response = JSON.parse(line);
+          if (response.error) {
+            reject(new Error(response.error));
+          } else {
+            resolve(response.result);
+          }
+        } catch (e) {
+          reject(new Error('Invalid response from Snip'));
+        }
+      }
+    });
+
+    conn.on('error', function (err) {
+      if ((err.code === 'ENOENT' || err.code === 'ECONNREFUSED') && !isRetry && !process.env.SNIP_NO_AUTO_LAUNCH) {
+        // Auto-launch Snip and retry
+        launchAndRetry(action, params).then(resolve).catch(reject);
+      } else if (err.code === 'ENOENT' || err.code === 'ECONNREFUSED') {
+        reject(new Error('Snip is not running and could not be launched.'));
+      } else {
+        reject(new Error('Connection failed: ' + err.message));
+      }
+    });
+
+    // Timeout for long-running commands (open blocks on user interaction)
+    if (action !== 'open_in_snip') {
+      setTimeout(function () {
+        conn.destroy();
+        reject(new Error('Request timed out'));
+      }, 30000);
+    }
+  });
+}
+
+function launchAndRetry(action, params) {
+  // Try to launch the packaged app
+  if (fs.existsSync('/Applications/Snip.app')) {
+    process.stderr.write('Launching Snip...\n');
+    require('child_process').exec('open -a Snip');
+  } else {
+    return Promise.reject(new Error('Snip is not running. Start it with: npm start'));
+  }
+
+  // Poll for socket to appear
+  return new Promise(function (resolve, reject) {
+    var attempts = 0;
+    var check = function () {
+      attempts++;
+      if (attempts > 20) {
+        return reject(new Error('Snip did not start in time'));
+      }
+      if (fs.existsSync(SOCKET_PATH)) {
+        // Socket appeared — retry the call
+        callSnip(action, params, true).then(resolve).catch(reject);
+      } else {
+        setTimeout(check, 500);
+      }
+    };
+    setTimeout(check, 500);
+  });
+}
+
+// ── Output formatting ──
+
+function formatOutput(command, result) {
+  if (command === 'transcribe') {
+    if (result && result.text) {
+      process.stdout.write(result.text + '\n');
+    } else if (result && result.success === false) {
+      process.stderr.write('Transcription failed: ' + (result.error || 'unknown error') + '\n');
+      process.exit(1);
+    } else {
+      printJson(result);
+    }
+    return;
+  }
+
+  if (command === 'open') {
+    var outPath = null;
+    if (result && result.outputPath) {
+      outPath = result.outputPath;
+    } else if (result && result.dataURL) {
+      var tmpDir = path.join(os.homedir(), 'Documents', 'snip', 'screenshots', '.tmp');
+      fs.mkdirSync(tmpDir, { recursive: true });
+      var filename = 'annotated-' + Date.now() + '.png';
+      outPath = path.join(tmpDir, filename);
+      var raw = Buffer.from(result.dataURL.split(',')[1], 'base64');
+      fs.writeFileSync(outPath, raw);
+    }
+    if (outPath) {
+      printJson({ status: 'edited', path: outPath, message: 'User annotated the image. Read the file at path to see the result.' });
+    }
+    return;
+  }
+
+  if (command === 'get') {
+    if (result && result.metadata) {
+      printJson(result.metadata);
+    } else {
+      printJson(result);
+    }
+    return;
+  }
+
+  if (command === 'organize') {
+    if (result && result.queued) {
+      process.stdout.write('Queued for AI categorization: ' + result.filepath + '\n');
+    } else {
+      printJson(result);
+    }
+    return;
+  }
+
+  printJson(result);
+}
+
+function printJson(data) {
+  if (flags.pretty) {
+    process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+  } else {
+    process.stdout.write(JSON.stringify(data) + '\n');
+  }
+}
+
+function printHelp() {
+  process.stdout.write([
+    'Usage: snip <command> [options]',
+    '',
+    'Commands:',
+    '  search <query>        Search screenshots by description',
+    '  list                  List all saved screenshots',
+    '  get <filepath>        Get screenshot metadata',
+    '  transcribe <filepath> Extract text from a screenshot (OCR)',
+    '  organize <filepath>   Queue screenshot for AI categorization',
+    '  categories            List all categories',
+    '  open <filepath>       Open image in Snip editor for annotation',
+    '',
+    'Options:',
+    '  --pretty              Pretty-print JSON output',
+    '  --help, -h            Show this help',
+    '',
+    'Snip auto-launches if not running (packaged app).',
+    '',
+    'Examples:',
+    '  snip search "error message"',
+    '  snip list | jq \'.[].name\'',
+    '  snip transcribe ~/Documents/snip/screenshots/code/api.png',
+    '  snip open mockup.png',
+    ''
+  ].join('\n'));
+}

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -345,20 +345,10 @@ function registerIpcHandlers(getOverlayWindow, createEditorWindowFn, reregisterS
   });
 
   ipcMain.handle('set-mcp-config', async (event, update) => {
-    var before = getMcpConfig();
     setMcpConfig(update);
     var after = getMcpConfig();
 
-    // Start or stop the socket server based on toggle
-    if (after.enabled && !before.enabled) {
-      var { startMcpServer } = require('./main');
-      startMcpServer();
-    } else if (!after.enabled && before.enabled) {
-      var { stopSocketServer } = require('./socket-server');
-      stopSocketServer();
-    }
-
-    // Broadcast change to all windows
+    // Broadcast change to all windows (MCP toggle controls UI visibility only)
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) win.webContents.send('mcp-config-changed', after);
     }
@@ -389,6 +379,194 @@ function registerIpcHandlers(getOverlayWindow, createEditorWindowFn, reregisterS
         }
       }
     };
+  });
+
+  // CLI + AI Integration
+  ipcMain.handle('install-cli', async () => {
+    var nodePath, cliPath;
+    if (app.isPackaged) {
+      nodePath = path.join(process.resourcesPath, 'node', 'node');
+      cliPath = path.join(process.resourcesPath, 'cli', 'snip.js');
+    } else {
+      var { findNodeBinary } = require('./node-binary');
+      nodePath = findNodeBinary() || '/usr/local/bin/node';
+      cliPath = path.join(__dirname, '..', 'cli', 'snip.js');
+    }
+
+    // Sanitize paths for shell safety (escape double quotes)
+    var safeNode = nodePath.replace(/"/g, '\\"');
+    var safeCli = cliPath.replace(/"/g, '\\"');
+    var wrapper = '#!/bin/sh\n# Snip CLI — installed by Snip.app\nexec "' + safeNode + '" "' + safeCli + '" "$@"\n';
+    var home = require('os').homedir();
+    var targets = [
+      '/usr/local/bin/snip',
+      path.join(home, '.local', 'bin', 'snip'),
+      path.join(home, 'bin', 'snip')
+    ];
+
+    for (var target of targets) {
+      try {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, wrapper, { mode: 0o755 });
+        // Check if the directory is in PATH
+        var dir = path.dirname(target);
+        var inPath = (process.env.PATH || '').split(':').includes(dir);
+        return {
+          installed: true,
+          path: target,
+          inPath: inPath,
+          addToPath: inPath ? null : 'export PATH="' + dir + ':$PATH"'
+        };
+      } catch {}
+    }
+    return { error: 'Could not install CLI. Run manually: sudo ln -sf "' + safeCli + '" /usr/local/bin/snip' };
+  });
+
+  ipcMain.handle('detect-ai-providers', async () => {
+    var home = require('os').homedir();
+    var providers = [];
+    if (fs.existsSync(path.join(home, '.claude'))) {
+      providers.push({ id: 'claude-code', name: 'Claude Code' });
+    }
+    if (fs.existsSync(path.join(home, '.cursor')) || fs.existsSync(path.join(home, 'Library', 'Application Support', 'Cursor'))) {
+      providers.push({ id: 'cursor', name: 'Cursor' });
+    }
+    if (fs.existsSync(path.join(home, '.windsurf')) || fs.existsSync(path.join(home, 'Library', 'Application Support', 'Windsurf'))) {
+      providers.push({ id: 'windsurf', name: 'Windsurf' });
+    }
+    if (fs.existsSync(path.join(home, '.cline'))) {
+      providers.push({ id: 'cline', name: 'Cline' });
+    }
+    return providers;
+  });
+
+  // Shared: map provider ID → file path for Snip rules
+  var SNIP_MARKER_START = '<!-- snip-start -->';
+  var SNIP_MARKER_END = '<!-- snip-end -->';
+
+  function getProviderFilePath(providerId) {
+    var home = require('os').homedir();
+    switch (providerId) {
+      case 'claude-code': return path.join(home, '.claude', 'CLAUDE.md');
+      case 'cursor': return path.join(home, '.cursor', 'rules', 'snip.mdc');
+      case 'windsurf': return path.join(home, '.windsurf', 'rules', 'snip.md');
+      case 'cline': return path.join(home, '.cline', 'rules', 'snip.md');
+      default: return null;
+    }
+  }
+
+  var snipRulesContent = [
+    '# Snip — Image Editor',
+    'For any image editing, annotation, markup, highlighting, or visual feedback, use the `snip` CLI.',
+    '- `snip open <filepath>` — Opens image in Snip editor. Blocks until done. Returns JSON: `{"status":"edited","path":"...","message":"..."}`. Read the file at `path` to see the annotated result. If the user cancels, the command exits with code 1.',
+    '- `snip search "<query>"` — Search screenshot library. Returns JSON array.',
+    '- `snip list` — List saved screenshots with metadata. Returns JSON array.',
+    '- `snip transcribe <filepath>` — Extract text via OCR. Returns plain text.',
+    '- `snip categories` — List categories. Returns JSON array.',
+    '- `snip open` auto-launches Snip if not running.',
+    'Always prefer `snip open` when the user wants to show, point out, or mark up something visually.',
+    ''
+  ].join('\n');
+
+  ipcMain.handle('check-ai-provider-status', async (event, providerId) => {
+    var filePath = getProviderFilePath(providerId);
+    if (!filePath) return false;
+    if (providerId === 'claude-code') {
+      // Check for marker in CLAUDE.md
+      try {
+        var content = fs.readFileSync(filePath, 'utf8');
+        return content.includes(SNIP_MARKER_START);
+      } catch { return false; }
+    }
+    return fs.existsSync(filePath);
+  });
+
+  ipcMain.handle('configure-ai-provider', async (event, providerId) => {
+    var filePath = getProviderFilePath(providerId);
+    if (!filePath) return { error: 'Unknown provider' };
+
+    try {
+      if (providerId === 'claude-code') {
+        // Append to CLAUDE.md with markers
+        var block = '\n' + SNIP_MARKER_START + '\n' + snipRulesContent + SNIP_MARKER_END + '\n';
+        // Check if already configured
+        var existing = '';
+        try { existing = fs.readFileSync(filePath, 'utf8'); } catch {}
+        if (existing.includes(SNIP_MARKER_START)) {
+          return { configured: true, provider: 'Claude Code' }; // already there
+        }
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.appendFileSync(filePath, block);
+      } else {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, snipRulesContent);
+      }
+      return { configured: true, provider: providerId };
+    } catch (err) {
+      return { error: err.message };
+    }
+  });
+
+  ipcMain.handle('remove-ai-provider', async (event, providerId) => {
+    var filePath = getProviderFilePath(providerId);
+    if (!filePath) return { error: 'Unknown provider' };
+
+    try {
+      if (providerId === 'claude-code') {
+        // Remove the marked block from CLAUDE.md
+        var content = '';
+        try { content = fs.readFileSync(filePath, 'utf8'); } catch { return { removed: true }; }
+        var startIdx = content.indexOf(SNIP_MARKER_START);
+        var endIdx = content.indexOf(SNIP_MARKER_END);
+        if (startIdx === -1) return { removed: true }; // already gone
+        if (endIdx === -1 || endIdx < startIdx) return { removed: true }; // corrupt markers, leave file alone
+        // Remove the block including surrounding newlines
+        var cutStart = startIdx;
+        if (cutStart > 0 && content[cutStart - 1] === '\n') cutStart--;
+        var cutEnd = endIdx + SNIP_MARKER_END.length;
+        if (cutEnd < content.length && content[cutEnd] === '\n') cutEnd++;
+        var before = content.slice(0, cutStart);
+        var after = content.slice(cutEnd);
+        fs.writeFileSync(filePath, before + after);
+      } else {
+        fs.rmSync(filePath, { force: true });
+      }
+      return { removed: true };
+    } catch (err) {
+      return { error: err.message };
+    }
+  });
+
+  ipcMain.handle('check-cli-installed', async () => {
+    var home = require('os').homedir();
+    var targets = ['/usr/local/bin/snip', path.join(home, '.local', 'bin', 'snip'), path.join(home, 'bin', 'snip')];
+    for (var target of targets) {
+      if (fs.existsSync(target)) {
+        // Verify the wrapper still points to a valid node binary
+        try {
+          var content = fs.readFileSync(target, 'utf8');
+          var match = content.match(/exec "([^"]+)"/);
+          if (match && match[1] && !fs.existsSync(match[1])) {
+            return 'stale'; // wrapper exists but points to deleted app
+          }
+        } catch {}
+        return true;
+      }
+    }
+    return false;
+  });
+
+  ipcMain.handle('uninstall-cli', async () => {
+    var home = require('os').homedir();
+    var targets = ['/usr/local/bin/snip', path.join(home, '.local', 'bin', 'snip'), path.join(home, 'bin', 'snip')];
+    var removed = false;
+    for (var target of targets) {
+      try {
+        fs.rmSync(target, { force: true });
+        removed = true;
+      } catch {}
+    }
+    return { removed: removed };
   });
 
   // Settings: User Extensions

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -408,10 +408,8 @@ app.whenReady().then(() => {
   // Pre-warm overlay window for fast first capture
   prewarmOverlay();
 
-  // Start MCP socket server if enabled in settings
-  if (getMcpConfig().enabled) {
-    startMcpServer();
-  }
+  // Always start socket server (CLI depends on it; MCP toggle only controls UI visibility)
+  startSocketHandlers();
 
   // Open home window on startup
   showHomeWindow();
@@ -465,13 +463,25 @@ function requireCategory(category) {
 var pendingMcpResolve = null; // { resolve, reject, webContentsId, win }
 
 ipcMain.on('editor-result', function (event, dataURL) {
-  if (!pendingMcpResolve) return;
+  if (!pendingMcpResolve || typeof pendingMcpResolve !== 'object') return;
   // Only accept results from the editor window that was opened for this upload
   if (event.sender.id !== pendingMcpResolve.webContentsId) return;
   var { resolve, reject, win } = pendingMcpResolve;
   pendingMcpResolve = null;
   if (dataURL && typeof dataURL === 'string' && dataURL.startsWith('data:image/')) {
-    resolve({ dataURL: dataURL });
+    // Save annotated image to Snip temp space for CLI access
+    try {
+      var store = require('./store');
+      var tmpDir = path.join(store.getScreenshotsDir(), '.tmp');
+      require('fs').mkdirSync(tmpDir, { recursive: true });
+      var filename = 'annotated-' + Date.now() + '.png';
+      var outputPath = path.join(tmpDir, filename);
+      var raw = Buffer.from(dataURL.split(',')[1], 'base64');
+      require('fs').writeFileSync(outputPath, raw);
+      resolve({ dataURL: dataURL, outputPath: outputPath });
+    } catch (e) {
+      resolve({ dataURL: dataURL });
+    }
   } else if (dataURL) {
     reject(new Error('Invalid editor result'));
   } else {
@@ -481,7 +491,7 @@ ipcMain.on('editor-result', function (event, dataURL) {
   if (win && !win.isDestroyed()) win.destroy();
 });
 
-function startMcpServer() {
+function startSocketHandlers() {
   startSocketServer({
     search_screenshots: async function (params) {
       requireCategory('library');
@@ -536,8 +546,8 @@ function startMcpServer() {
       // Check editor is not already busy
       if (pendingMcpResolve) throw new Error('Editor is busy with another upload');
 
-      // Reserve the slot immediately to prevent concurrent uploads
-      pendingMcpResolve = { resolve: null, reject: null, webContentsId: null, win: null };
+      // Reserve the slot with a truthy sentinel (not destructurable — prevents crash if editor-result fires early)
+      pendingMcpResolve = true;
 
       try {
 
@@ -635,7 +645,7 @@ function startMcpServer() {
           var { setPendingEditorData } = require('./ipc-handlers');
           setPendingEditorData(null);
 
-          if (pendingMcpResolve) {
+          if (pendingMcpResolve && typeof pendingMcpResolve === 'object' && pendingMcpResolve.reject) {
             pendingMcpResolve.reject(new Error('Editor closed without saving'));
             pendingMcpResolve = null;
           }
@@ -723,4 +733,4 @@ function startMcpServer() {
   });
 }
 
-module.exports = { startMcpServer };
+module.exports = { startSocketHandlers };

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -3,203 +3,191 @@
 /**
  * Snip MCP Server — stdio transport.
  *
- * This is a thin adapter between the MCP protocol (JSON-RPC 2.0 over stdio)
- * and the running Snip Electron app (via Unix domain socket).
+ * Thin adapter between MCP protocol (JSON-RPC 2.0 over stdio)
+ * and the Snip CLI. All tool calls spawn `snip <command>` and
+ * read stdout. No direct socket management.
  *
  * Usage:
  *   node src/mcp/server.js
- *
- * MCP client config (Claude Desktop, etc.):
- *   {
- *     "mcpServers": {
- *       "snip": {
- *         "command": "node",
- *         "args": ["/path/to/snip/src/mcp/server.js"]
- *       }
- *     }
- *   }
  */
 
-const net = require('net');
-const path = require('path');
-const os = require('os');
+var path = require('path');
+var { execFile } = require('child_process');
 
-const SOCKET_PATH = path.join(
-  os.homedir(), 'Library', 'Application Support', 'snip', 'snip.sock'
-);
+// Resolve CLI path and Node binary
+var CLI_PATH;
+var NODE_PATH;
 
-const PROTOCOL_VERSION = '2025-11-25';
-const SERVER_NAME = 'snip';
-const SERVER_VERSION = '1.0.0';
+// In packaged app: CLI is in Resources/cli/, Node is in Resources/node/
+// In dev: CLI is at src/cli/snip.js, use system node
+var isPackaged = false;
+try { isPackaged = require('fs').existsSync(path.join(__dirname, '..', '..', 'app.asar')); } catch {}
+
+if (isPackaged || __dirname.includes('app.asar')) {
+  var resourcesPath = path.resolve(__dirname, '..', '..', '..');
+  CLI_PATH = path.join(resourcesPath, 'cli', 'snip.js');
+  NODE_PATH = path.join(resourcesPath, 'node', 'node');
+  // Fallback to system node if bundled node not found
+  if (!require('fs').existsSync(NODE_PATH)) {
+    NODE_PATH = '/usr/local/bin/node';
+  }
+} else {
+  CLI_PATH = path.join(__dirname, '..', 'cli', 'snip.js');
+  NODE_PATH = process.argv[0]; // The node binary that launched this script
+}
+
+var PROTOCOL_VERSION = '2025-11-25';
+var SERVER_NAME = 'snip';
+var SERVER_VERSION = '1.0.0';
 
 // ── MCP Tool Definitions ──
 
-const TOOLS = [
+var TOOLS = [
   {
     name: 'search_screenshots',
-    description: 'Search the user\'s Snip screenshot library using natural language. USE THIS whenever the user asks to find, look up, or search for a screenshot or image they saved before. Uses semantic embeddings for relevance ranking. Returns matching entries with category, name, description, tags, relevance score, and file path. Use get_screenshot to retrieve the actual image, or open_in_snip to let the user edit it.',
+    description: 'Search Snip screenshot library by description. USE THIS to find saved screenshots.',
     inputSchema: {
       type: 'object',
-      properties: {
-        query: { type: 'string', description: 'Natural language search query (e.g. "login form", "error message", "chart")' }
-      },
+      properties: { query: { type: 'string', description: 'Search query' } },
       required: ['query']
     }
   },
   {
     name: 'list_screenshots',
-    description: 'List all screenshots saved in Snip with their metadata (category, name, description, tags, file path, timestamp). USE THIS when the user wants to browse or see all their saved snips. Use get_screenshot with a file path to retrieve an image, or open_in_snip to edit it.',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-      required: []
-    }
+    description: 'List all saved screenshots with metadata.',
+    inputSchema: { type: 'object', properties: {}, required: [] }
   },
   {
     name: 'get_screenshot',
-    description: 'Retrieve a specific screenshot image from the Snip library by file path. Returns the image and its metadata. Use list_screenshots or search_screenshots first to discover valid paths. To let the user edit the image, pass the path to open_in_snip instead.',
+    description: 'Get screenshot metadata by file path.',
     inputSchema: {
       type: 'object',
-      properties: {
-        filepath: { type: 'string', description: 'Absolute path to the screenshot file, as returned by list_screenshots or search_screenshots' }
-      },
+      properties: { filepath: { type: 'string', description: 'Absolute path to screenshot' } },
       required: ['filepath']
     }
   },
   {
     name: 'transcribe_screenshot',
-    description: 'Extract text from a screenshot using Snip\'s OCR (macOS Vision framework). USE THIS whenever the user wants to read, extract, or copy text from an image. Returns recognized text and detected languages. Works with code, documents, UI labels, error messages, and any readable text.',
+    description: 'Extract text from a screenshot via OCR. USE THIS to read text from images.',
     inputSchema: {
       type: 'object',
-      properties: {
-        filepath: { type: 'string', description: 'Absolute path to the screenshot file, as returned by list_screenshots or search_screenshots' }
-      },
+      properties: { filepath: { type: 'string', description: 'Absolute path to screenshot' } },
       required: ['filepath']
     }
   },
   {
     name: 'organize_screenshot',
-    description: 'Have Snip\'s AI categorize a screenshot. A local vision LLM analyzes the image and assigns a category, descriptive name, description, and tags. Processing happens in the background. The file must be inside the screenshots directory.',
+    description: 'Queue screenshot for AI categorization.',
     inputSchema: {
       type: 'object',
-      properties: {
-        filepath: { type: 'string', description: 'Absolute path to the screenshot file to categorize' }
-      },
+      properties: { filepath: { type: 'string', description: 'Absolute path to screenshot' } },
       required: ['filepath']
     }
   },
   {
     name: 'get_categories',
-    description: 'List all Snip screenshot categories (default and custom). Use this to see what organizational categories exist before calling organize_screenshot.',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-      required: []
-    }
+    description: 'List all screenshot categories.',
+    inputSchema: { type: 'object', properties: {}, required: [] }
   },
   {
     name: 'open_in_snip',
-    description: 'Open an image in Snip\'s editor for the user to annotate, mark up, or edit. THIS IS THE PRIMARY IMAGE EDITING TOOL — use it whenever the user wants to edit, annotate, mark up, highlight, redact, blur, add arrows, add text, or draw on any image. Also use it when the user wants to review or comment on an image visually. Pass a local file path (preferred) or base64 data URL. The editor provides rectangles, arrows, text labels, tags, blur brush, and more. Blocks until the user finishes and returns the annotated result. PNG and JPEG, max 15 MB.',
+    description: 'Open image in Snip editor for annotation. THIS IS THE PRIMARY IMAGE EDITING TOOL — use it to edit, annotate, highlight, redact, blur, or draw on any image. Blocks until user finishes. Returns path to annotated image.',
     inputSchema: {
       type: 'object',
       properties: {
-        imageDataURL: { type: 'string', description: 'Base64 data URL of the image (e.g. data:image/png;base64,iVBOR...). Use this from Claude Desktop or any sandboxed MCP client.' },
-        filepath: { type: 'string', description: 'Absolute path to an image file on the local filesystem. Only works from CLI tools (e.g. Claude Code) that share the same filesystem as Snip.' }
+        filepath: { type: 'string', description: 'Path to image file (PNG/JPEG)' },
+        imageDataURL: { type: 'string', description: 'Base64 data URL (fallback for sandboxed clients)' }
       },
       required: []
     }
   },
   {
     name: 'install_extension',
-    description: 'Install a new extension into Snip. Shows the user an approval dialog before installing. The extension runs in a sandboxed child process — it cannot access fs, child_process, net, http, or electron directly. Only action-tool and processor types are supported.\n\nHow to create an extension:\n1. Choose a name (alphanumeric + hyphens, e.g. "word-counter")\n2. Create a manifest object with: name, displayName, type ("action-tool" or "processor"), and an ipc array mapping channels to methods\n3. All IPC channels MUST use the "ext:" prefix (e.g. "ext:word-counter:count")\n4. Write mainCode that exports the methods referenced in the ipc array. Use module.exports = { methodName }.\n5. The mainCode runs in a sandbox: require("path"), require("crypto"), require("buffer") are allowed. require("fs"), require("child_process"), require("net"), etc. are blocked.\n6. For file access, declare permissions in the manifest: ["screenshots:read"] or ["temp:write"]. Use the context.api object passed to init(): context.api.readScreenshot(filepath), context.api.writeTemp(filename, data).\n\nExample:\n  name: "word-counter"\n  manifest: { name: "word-counter", displayName: "Word Counter", type: "action-tool", toolId: "word-counter", icon: "<svg .../>", tooltip: "Count Words", toolbarPosition: 11, ipc: [{ channel: "ext:word-counter:count", method: "count" }] }\n  mainCode: "async function count(event, { text }) { return { words: text.split(/\\\\s+/).length }; }\\nmodule.exports = { count };"',
+    description: 'Install a sandboxed extension into Snip. Requires user approval. Only action-tool and processor types. All IPC channels must use ext: prefix.\n\nExample:\n  name: "word-counter"\n  manifest: { name: "word-counter", displayName: "Word Counter", type: "action-tool", ipc: [{ channel: "ext:word-counter:count", method: "count" }] }\n  mainCode: "async function count(event, { text }) { return { words: text.split(/\\\\s+/).length }; }\\nmodule.exports = { count };"',
     inputSchema: {
       type: 'object',
       properties: {
-        name: { type: 'string', description: 'Extension name (alphanumeric + hyphens only, e.g. "word-counter")' },
-        manifest: {
-          type: 'object',
-          description: 'The extension.json manifest. Required fields: name (string), displayName (string), type ("action-tool" or "processor"). Optional: ipc (array of {channel, method}), permissions (array of "screenshots:read", "temp:write", "network"), toolId, icon (SVG string), tooltip, shortcut, toolbarPosition (number).'
-        },
-        mainCode: { type: 'string', description: 'JavaScript source code for main.js. Must use module.exports to export functions referenced by the ipc array. Runs in a sandboxed process. init(context) is called on load — context.api provides readScreenshot() and writeTemp() if permissions are declared.' }
+        name: { type: 'string', description: 'Extension name (alphanumeric + hyphens)' },
+        manifest: { type: 'object', description: 'Extension manifest object' },
+        mainCode: { type: 'string', description: 'JavaScript source for main.js' }
       },
       required: ['name', 'manifest']
     }
   }
 ];
 
-// ── Socket Connection ──
+// ── CLI execution ──
 
-let snipConn = null;
-let pendingRequests = {};
-let requestCounter = 0;
+function mapToolToCli(toolName, args) {
+  switch (toolName) {
+    case 'search_screenshots': return ['search', args.query || ''];
+    case 'list_screenshots': return ['list'];
+    case 'get_screenshot': return ['get', args.filepath || ''];
+    case 'transcribe_screenshot': return ['transcribe', args.filepath || ''];
+    case 'organize_screenshot': return ['organize', args.filepath || ''];
+    case 'get_categories': return ['categories'];
+    case 'open_in_snip':
+      // imageDataURL can't go through CLI (too large for argv, path.resolve breaks it)
+      if (!args.filepath && args.imageDataURL) return null;
+      return ['open', args.filepath || ''];
+    case 'install_extension': return null; // handled via socket directly
+    default: return null;
+  }
+}
 
-function connectToSnip() {
+function execCli(cliArgs, timeout) {
+  return new Promise(function (resolve, reject) {
+    var child = execFile(NODE_PATH, [CLI_PATH].concat(cliArgs), {
+      timeout: timeout !== undefined ? timeout : 30000,
+      maxBuffer: 50 * 1024 * 1024
+    }, function (err, stdout, stderr) {
+      if (err) {
+        reject(new Error(stderr.trim() || err.message));
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+  });
+}
+
+// For install_extension, we still need direct socket (it needs to pass complex JSON)
+var net = require('net');
+var os = require('os');
+var SOCKET_PATH = path.join(os.homedir(), 'Library', 'Application Support', 'snip', 'snip.sock');
+
+function callSocket(action, params) {
   return new Promise(function (resolve, reject) {
     var conn = net.createConnection(SOCKET_PATH);
     var buffer = '';
+    var id = 'mcp-' + Date.now();
 
     conn.on('connect', function () {
-      snipConn = conn;
-      resolve(conn);
+      conn.write(JSON.stringify({ id: id, action: action, params: params || {} }) + '\n');
     });
 
     conn.on('data', function (chunk) {
       buffer += chunk.toString();
-      var newlineIdx;
-      while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
-        var line = buffer.slice(0, newlineIdx).trim();
-        buffer = buffer.slice(newlineIdx + 1);
-        if (!line) continue;
-
+      var idx = buffer.indexOf('\n');
+      if (idx !== -1) {
+        var line = buffer.slice(0, idx).trim();
+        conn.end();
         try {
-          var response = JSON.parse(line);
-          var pending = pendingRequests[response.id];
-          if (pending) {
-            delete pendingRequests[response.id];
-            if (response.error) {
-              pending.reject(new Error(response.error));
-            } else {
-              pending.resolve(response.result);
-            }
-          }
-        } catch {}
+          var resp = JSON.parse(line);
+          if (resp.error) reject(new Error(resp.error));
+          else resolve(resp.result);
+        } catch { reject(new Error('Invalid response')); }
       }
     });
 
     conn.on('error', function (err) {
-      snipConn = null;
-      reject(new Error('Cannot connect to Snip app. Is it running? (' + err.message + ')'));
-    });
-
-    conn.on('close', function () {
-      snipConn = null;
-      // Reject all pending requests
-      Object.keys(pendingRequests).forEach(function (id) {
-        pendingRequests[id].reject(new Error('Connection to Snip closed'));
-        delete pendingRequests[id];
-      });
+      reject(new Error('Cannot connect to Snip: ' + err.message));
     });
   });
 }
 
-function callSnip(action, params) {
-  return new Promise(function (resolve, reject) {
-    if (!snipConn) {
-      reject(new Error('Not connected to Snip app'));
-      return;
-    }
+// ── MCP Protocol ──
 
-    var id = 'mcp-' + (++requestCounter);
-    pendingRequests[id] = { resolve: resolve, reject: reject };
-
-    var msg = JSON.stringify({ id: id, action: action, params: params || {} }) + '\n';
-    snipConn.write(msg);
-  });
-}
-
-// ── MCP Protocol Handler ──
-
-var useFramedOutput = false; // set by auto-detect in transport
+var useFramedOutput = false;
 
 function sendJsonRpc(obj) {
   var json = JSON.stringify(obj);
@@ -233,7 +221,6 @@ async function handleRequest(msg) {
       break;
 
     case 'notifications/initialized':
-      // No-op — client is ready
       break;
 
     case 'tools/list':
@@ -260,28 +247,36 @@ async function handleToolCall(id, params) {
   var args = params.arguments || {};
 
   try {
-    // Ensure connection to Snip app
-    if (!snipConn) {
-      await connectToSnip();
-    }
-
-    var result = await callSnip(toolName, args);
-
-    // Format result as MCP content
     var content;
-    if (result && result.dataURL) {
-      // Image result — return as image content
-      var match = result.dataURL.match(/^data:(image\/\w+);base64,(.+)$/);
-      if (match) {
-        content = [
-          { type: 'image', data: match[2], mimeType: match[1] },
-          { type: 'text', text: JSON.stringify({ width: result.width, height: result.height }, null, 2) }
-        ];
-      } else {
-        content = [{ type: 'text', text: JSON.stringify(result, null, 2) }];
-      }
-    } else {
+
+    if (toolName === 'install_extension') {
+      // install_extension needs direct socket (complex JSON params)
+      var result = await callSocket('install_extension', args);
       content = [{ type: 'text', text: JSON.stringify(result, null, 2) }];
+    } else {
+      var cliArgs = mapToolToCli(toolName, args);
+      if (!cliArgs) {
+        // Fallback to direct socket for tools that can't go through CLI (e.g., open_in_snip with imageDataURL)
+        var socketResult = await callSocket(toolName === 'open_in_snip' ? 'open_in_snip' : toolName, args);
+        content = [{ type: 'text', text: JSON.stringify(socketResult, null, 2) }];
+        sendResult(id, { content: content });
+        return;
+      }
+
+      // open_in_snip blocks indefinitely — no timeout
+      var timeout = toolName === 'open_in_snip' ? 0 : 30000;
+      var stdout = await execCli(cliArgs, timeout);
+
+      if (toolName === 'open_in_snip') {
+        // stdout is a file path — return it
+        content = [{ type: 'text', text: 'Annotated image saved to: ' + stdout }];
+      } else if (toolName === 'transcribe_screenshot') {
+        // stdout is plain text
+        content = [{ type: 'text', text: stdout }];
+      } else {
+        // stdout is JSON
+        content = [{ type: 'text', text: stdout }];
+      }
     }
 
     sendResult(id, { content: content });
@@ -293,55 +288,37 @@ async function handleToolCall(id, params) {
   }
 }
 
-// ── Stdio Transport ──
+// ── Stdio Transport (auto-detect framing) ──
 
 function startStdioTransport() {
-  let buffer = '';
-  let contentLength = null;
-  let framed = null; // null = auto-detect, true = Content-Length framing, false = newline-delimited
+  var buffer = '';
+  var contentLength = null;
+  var framed = null;
 
   function processMessage(body) {
     try {
       var msg = JSON.parse(body);
       handleRequest(msg).catch(function (err) {
-        if (msg.id !== undefined) {
-          sendError(msg.id, -32603, err.message);
-        }
+        if (msg.id !== undefined) sendError(msg.id, -32603, err.message);
       });
-    } catch (err) {
-      // Invalid JSON — skip
-    }
+    } catch {}
   }
 
   function processFramed() {
     while (buffer.length > 0) {
       if (contentLength === null) {
-        // Look for header separator (accept \r\n\r\n and \n\n)
         var headerEnd = buffer.indexOf('\r\n\r\n');
         var sepLen = 4;
-        if (headerEnd === -1) {
-          headerEnd = buffer.indexOf('\n\n');
-          sepLen = 2;
-        }
+        if (headerEnd === -1) { headerEnd = buffer.indexOf('\n\n'); sepLen = 2; }
         if (headerEnd === -1) return;
-
         var header = buffer.slice(0, headerEnd);
         var match = header.match(/Content-Length:\s*(\d+)/i);
-        if (!match) {
-          buffer = buffer.slice(headerEnd + sepLen);
-          continue;
-        }
+        if (!match) { buffer = buffer.slice(headerEnd + sepLen); continue; }
         contentLength = parseInt(match[1]);
-        if (contentLength > 10 * 1024 * 1024) {
-          buffer = buffer.slice(headerEnd + sepLen);
-          contentLength = null;
-          continue;
-        }
+        if (contentLength > 10 * 1024 * 1024) { buffer = buffer.slice(headerEnd + sepLen); contentLength = null; continue; }
         buffer = buffer.slice(headerEnd + sepLen);
       }
-
       if (buffer.length < contentLength) return;
-
       var body = buffer.slice(0, contentLength);
       buffer = buffer.slice(contentLength);
       contentLength = null;
@@ -350,48 +327,27 @@ function startStdioTransport() {
   }
 
   function processLines() {
-    var newlineIdx;
-    while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
-      var line = buffer.slice(0, newlineIdx).trim();
-      buffer = buffer.slice(newlineIdx + 1);
-      if (!line) continue;
-      processMessage(line);
+    var idx;
+    while ((idx = buffer.indexOf('\n')) !== -1) {
+      var line = buffer.slice(0, idx).trim();
+      buffer = buffer.slice(idx + 1);
+      if (line) processMessage(line);
     }
   }
 
   process.stdin.on('data', function (chunk) {
     buffer += chunk.toString();
-
-    // Guard against unbounded buffer growth
-    if (buffer.length > 16 * 1024 * 1024) {
-      buffer = '';
-      return;
-    }
-
-    // Auto-detect framing on first data
+    if (buffer.length > 16 * 1024 * 1024) { buffer = ''; return; }
     if (framed === null) {
       var trimmed = buffer.trimStart();
-      if (trimmed.startsWith('{')) {
-        framed = false; // newline-delimited JSON
-        useFramedOutput = false;
-      } else {
-        framed = true; // Content-Length framed
-        useFramedOutput = true;
-      }
+      if (trimmed.startsWith('{')) { framed = false; useFramedOutput = false; }
+      else { framed = true; useFramedOutput = true; }
     }
-
-    if (framed) {
-      processFramed();
-    } else {
-      processLines();
-    }
+    if (framed) processFramed();
+    else processLines();
   });
 
-  process.stdin.on('end', function () {
-    process.exit(0);
-  });
+  process.stdin.on('end', function () { process.exit(0); });
 }
-
-// ── Main ──
 
 startStdioTransport();

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -123,6 +123,15 @@ contextBridge.exposeInMainWorld('snip', {
   getAnimationConfig: () => ipcRenderer.invoke('get-animation-config'),
   setAnimationConfig: (config) => ipcRenderer.invoke('set-animation-config', config),
 
+  // CLI + AI Integration
+  installCli: () => ipcRenderer.invoke('install-cli'),
+  uninstallCli: () => ipcRenderer.invoke('uninstall-cli'),
+  checkCliInstalled: () => ipcRenderer.invoke('check-cli-installed'),
+  detectAiProviders: () => ipcRenderer.invoke('detect-ai-providers'),
+  configureAiProvider: (id) => ipcRenderer.invoke('configure-ai-provider', id),
+  removeAiProvider: (id) => ipcRenderer.invoke('remove-ai-provider', id),
+  checkAiProviderStatus: (id) => ipcRenderer.invoke('check-ai-provider-status', id),
+
   // Settings: User Extensions
   getUserExtensions: () => ipcRenderer.invoke('get-user-extensions'),
   removeUserExtension: (name) => ipcRenderer.invoke('remove-user-extension', name),

--- a/src/renderer/home.css
+++ b/src/renderer/home.css
@@ -1420,6 +1420,165 @@ input:focus { border-color: var(--accent); }
 .extensions-status.visible { opacity: 1; }
 .extensions-status.error { color: var(--error); }
 
+/* AI Workflow Integration subsections */
+.ai-subsection {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.ai-subsection:first-of-type {
+  margin-top: 12px;
+  padding-top: 0;
+  border-top: none;
+}
+
+.ai-subsection h4 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.ai-subsection-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+
+/* CLI + AI integration */
+.cli-section-top {
+  margin-top: 8px;
+}
+
+.install-cli-btn-primary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  background: rgba(139, 92, 246, 0.1);
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.install-cli-btn-primary:hover {
+  background: rgba(139, 92, 246, 0.2);
+}
+
+.install-cli-btn-installed {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border: 1px solid var(--success);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--success);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.install-cli-btn-installed:hover {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.cli-description {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 10px 0 12px;
+  line-height: 1.5;
+}
+
+.cli-description code {
+  font-family: 'SF Mono', 'Menlo', monospace;
+  font-size: 11px;
+  background: rgba(139, 92, 246, 0.15);
+  color: var(--accent);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+.cli-install-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.ai-providers {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ai-provider-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.ai-provider-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ai-provider-status {
+  font-size: 11px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.4);
+  font-family: 'SF Mono', 'Menlo', monospace;
+}
+
+.ai-provider-btn {
+  -webkit-appearance: none;
+  appearance: none;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 5px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.ai-provider-btn:hover {
+  color: rgba(255, 255, 255, 0.9);
+  border-color: var(--accent, #8b5cf6);
+  background: rgba(139, 92, 246, 0.1);
+}
+
+.ai-provider-btn.configured {
+  color: var(--success, #22c55e);
+  border-color: var(--success, #22c55e);
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.ai-provider-btn.configured:hover {
+  color: var(--error, #ef4444);
+  border-color: var(--error, #ef4444);
+  background: rgba(239, 68, 68, 0.08);
+}
+
 kbd {
   display: inline-block;
   padding: 2px 7px;

--- a/src/renderer/home.html
+++ b/src/renderer/home.html
@@ -313,9 +313,30 @@
           </div>
         </div>
 
-        <div class="settings-section" id="mcp-section">
-          <h3>MCP Server</h3>
-          <p>Expose Snip's capabilities to AI assistants via the Model Context Protocol (MCP).</p>
+        <div class="settings-section" id="ai-workflow-section">
+          <h3>AI Workflow Integration</h3>
+          <p>Let AI assistants use Snip for image editing, annotation, and screenshot search.</p>
+
+          <div class="ai-subsection">
+            <h4>CLI</h4>
+            <p class="ai-subsection-desc">Recommended for AI coding tools that can run shell commands (Claude Code, Cursor, Windsurf, Cline). Lower latency and token cost than MCP.</p>
+            <div id="cli-section" class="cli-section-top">
+              <div class="cli-install-row">
+                <button id="install-cli-btn" class="install-cli-btn-primary">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>
+                  </svg>
+                  Install CLI
+                </button>
+                <span id="cli-status" class="extensions-status"></span>
+              </div>
+              <div id="ai-providers" class="ai-providers hidden"></div>
+            </div>
+          </div>
+
+          <div class="ai-subsection">
+            <h4>MCP Server</h4>
+            <p class="ai-subsection-desc">For clients that can't run CLI commands (e.g., Claude Desktop, web-based AI tools).</p>
           <div class="ai-toggle-row">
             <span class="ai-toggle-label">MCP Server</span>
             <span id="mcp-status-dot" class="status-dot stopped"></span>
@@ -370,6 +391,7 @@
                 <span class="mcp-copy-label">Copy</span>
               </button>
             </div>
+          </div>
           </div>
         </div>
 

--- a/src/renderer/home.js
+++ b/src/renderer/home.js
@@ -58,6 +58,7 @@
     initThemeToggle();
     initShortcutsSettings();
     initMcpSettings();
+    initCliSettings();
     initExtensionsSettings();
     initSetupOverlay();
   }
@@ -1202,6 +1203,147 @@
       window.snip.onMcpConfigChanged(function (config) {
         updateMcpUI(config);
       });
+    }
+  }
+
+  // ── CLI + AI Integration ──
+  async function initCliSettings() {
+    var installBtn = document.getElementById('install-cli-btn');
+    var cliStatus = document.getElementById('cli-status');
+    var aiProvidersDiv = document.getElementById('ai-providers');
+
+    if (!installBtn) return;
+
+    function showCliStatus(msg, isError) {
+      cliStatus.textContent = msg;
+      cliStatus.className = 'extensions-status visible' + (isError ? ' error' : '');
+      setTimeout(function () { cliStatus.className = 'extensions-status'; }, 4000);
+    }
+
+    // Check CLI state: true = installed, 'stale' = broken wrapper, false = not installed
+    var cliState = await window.snip.checkCliInstalled();
+
+    function updateCliButton(state) {
+      if (state === true) {
+        installBtn.textContent = 'CLI Installed ✓';
+        installBtn.className = 'install-cli-btn-installed';
+        installBtn.title = 'Click to remove CLI';
+      } else if (state === 'stale') {
+        installBtn.textContent = 'Update CLI';
+        installBtn.className = 'install-cli-btn-primary';
+        installBtn.title = 'CLI path changed — click to fix';
+        showCliStatus('CLI needs update — app path changed', true);
+      } else {
+        installBtn.textContent = 'Install CLI';
+        installBtn.className = 'install-cli-btn-primary';
+        installBtn.title = '';
+      }
+      if (state === true || state === 'stale') loadAiProviders();
+    }
+
+    updateCliButton(cliState);
+
+    installBtn.addEventListener('click', async function () {
+      if (cliState === true) {
+        // Remove CLI
+        await window.snip.uninstallCli();
+        cliState = false;
+        updateCliButton(false);
+        showCliStatus('CLI removed', false);
+        aiProvidersDiv.classList.add('hidden');
+      } else {
+        // Install or update CLI
+        var result = await window.snip.installCli();
+        if (result.error) {
+          showCliStatus(result.error, true);
+        } else {
+          cliState = true;
+          updateCliButton(true);
+          var msg = 'Installed at ' + result.path;
+          if (result.addToPath) msg += ' — add to your shell: ' + result.addToPath;
+          showCliStatus(msg, !result.inPath);
+        }
+      }
+    });
+
+    async function loadAiProviders() {
+      var providers = await window.snip.detectAiProviders();
+      if (providers.length === 0) {
+        aiProvidersDiv.classList.add('hidden');
+        return;
+      }
+
+      aiProvidersDiv.classList.remove('hidden');
+      aiProvidersDiv.innerHTML = '<div style="font-size:12px;color:var(--text-secondary);margin-bottom:4px;">Add Snip to your AI tools:</div>';
+
+      var PROVIDER_FILES = {
+        'claude-code': '~/.claude/CLAUDE.md',
+        'cursor': '~/.cursor/rules/snip.mdc',
+        'windsurf': '~/.windsurf/rules/snip.md',
+        'cline': '~/.cline/rules/snip.md'
+      };
+
+      for (var pi = 0; pi < providers.length; pi++) {
+        (async function (provider) {
+          var row = document.createElement('div');
+          row.className = 'ai-provider-row';
+
+          var nameCol = document.createElement('div');
+          nameCol.className = 'ai-provider-name';
+
+          var nameText = document.createElement('span');
+          nameText.textContent = provider.name;
+          nameCol.appendChild(nameText);
+
+          var statusText = document.createElement('span');
+          statusText.className = 'ai-provider-status';
+          nameCol.appendChild(statusText);
+
+          var isConfigured = await window.snip.checkAiProviderStatus(provider.id);
+
+          function updateStatus() {
+            var file = PROVIDER_FILES[provider.id] || '';
+            if (isConfigured) {
+              statusText.textContent = 'Added to ' + file;
+            } else {
+              statusText.textContent = '';
+            }
+          }
+          updateStatus();
+
+          var btn = document.createElement('button');
+          btn.className = 'ai-provider-btn' + (isConfigured ? ' configured' : '');
+          btn.textContent = isConfigured ? 'Remove' : 'Configure';
+
+          btn.addEventListener('click', async function () {
+            if (isConfigured) {
+              var result = await window.snip.removeAiProvider(provider.id);
+              if (!result.error) {
+                isConfigured = false;
+                btn.textContent = 'Configure';
+                btn.className = 'ai-provider-btn';
+                updateStatus();
+              } else {
+                showCliStatus(result.error, true);
+              }
+            } else {
+              var result = await window.snip.configureAiProvider(provider.id);
+              if (result.configured) {
+                isConfigured = true;
+                btn.textContent = 'Remove';
+                btn.className = 'ai-provider-btn configured';
+                updateStatus();
+              } else {
+                showCliStatus(result.error, true);
+              }
+            }
+          });
+
+          row.appendChild(nameCol);
+          row.appendChild(btn);
+          aiProvidersDiv.appendChild(row);
+        })(providers[pi]);
+      }
     }
   }
 

--- a/tests/cli/cli.test.js
+++ b/tests/cli/cli.test.js
@@ -1,0 +1,349 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFile } from 'child_process';
+import net from 'net';
+
+var CLI_PATH = join(__dirname, '..', '..', 'src', 'cli', 'snip.js');
+var NODE_PATH = process.execPath;
+
+let tmpDir;
+let socketPath;
+let server;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'snip-cli-test-'));
+  socketPath = join(tmpDir, 'test.sock');
+});
+
+afterEach(() => {
+  if (server) { server.close(); server = null; }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Helpers ──
+
+function runCli(args, opts) {
+  return new Promise((resolve) => {
+    execFile(NODE_PATH, [CLI_PATH].concat(args), {
+      env: { ...process.env, SNIP_SOCKET_PATH: socketPath, SNIP_NO_AUTO_LAUNCH: '1' },
+      timeout: (opts && opts.timeout) || 10000
+    }, (err, stdout, stderr) => {
+      resolve({
+        code: err ? (err.code || 1) : 0,
+        stdout: stdout.trim(),
+        stderr: stderr.trim()
+      });
+    });
+  });
+}
+
+function startTestServer(handlers) {
+  return new Promise((resolve) => {
+    server = net.createServer(function (conn) {
+      let buffer = '';
+      conn.on('data', function (chunk) {
+        buffer += chunk.toString();
+        let idx;
+        while ((idx = buffer.indexOf('\n')) !== -1) {
+          var line = buffer.slice(0, idx).trim();
+          buffer = buffer.slice(idx + 1);
+          if (!line) continue;
+          try {
+            var msg = JSON.parse(line);
+            handleMsg(conn, msg, handlers);
+          } catch {
+            conn.write(JSON.stringify({ id: null, error: 'Invalid JSON' }) + '\n');
+          }
+        }
+      });
+      conn.on('error', function () {});
+    });
+
+    async function handleMsg(conn, msg, handlers) {
+      var id = msg.id != null ? msg.id : null;
+      var action = msg.action;
+      var params = msg.params || {};
+      if (!action) { conn.write(JSON.stringify({ id, error: 'Missing action' }) + '\n'); return; }
+      var handler = handlers[action];
+      if (!handler) { conn.write(JSON.stringify({ id, error: 'Unknown action' }) + '\n'); return; }
+      try {
+        var result = await handler(params);
+        conn.write(JSON.stringify({ id, result }) + '\n');
+      } catch (err) {
+        conn.write(JSON.stringify({ id, error: err.message }) + '\n');
+      }
+    }
+
+    server.listen(socketPath, function () {
+      resolve();
+    });
+  });
+}
+
+// ── Help and argument parsing ──
+
+describe('CLI help and args', () => {
+  it('--help exits 0 with usage text', async () => {
+    var res = await runCli(['--help']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain('Usage:');
+    expect(res.stdout).toContain('Commands:');
+  });
+
+  it('-h exits 0 with usage text', async () => {
+    var res = await runCli(['-h']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain('Usage:');
+  });
+
+  it('no args shows help and exits 0', async () => {
+    var res = await runCli([]);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain('Usage:');
+  });
+
+  it('unknown command exits 1', async () => {
+    var res = await runCli(['foobar']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toContain('Unknown command');
+  });
+
+  it('missing required arg for search exits 1', async () => {
+    await startTestServer({});
+    var res = await runCli(['search']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toContain('Missing argument');
+  });
+
+  it('missing required arg for get exits 1', async () => {
+    await startTestServer({});
+    var res = await runCli(['get']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toContain('Missing argument');
+  });
+
+  it('missing required arg for transcribe exits 1', async () => {
+    await startTestServer({});
+    var res = await runCli(['transcribe']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toContain('Missing argument');
+  });
+});
+
+// ── Command output formatting ──
+
+describe('CLI commands', () => {
+  it('list returns JSON array', async () => {
+    await startTestServer({
+      list_screenshots: async () => [{ name: 'test', category: 'code' }]
+    });
+    var res = await runCli(['list']);
+    expect(res.code).toBe(0);
+    var data = JSON.parse(res.stdout);
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0].name).toBe('test');
+  });
+
+  it('search passes query and returns results', async () => {
+    var receivedQuery = null;
+    await startTestServer({
+      search_screenshots: async (params) => {
+        receivedQuery = params.query;
+        return [{ name: 'match', score: 0.9 }];
+      }
+    });
+    var res = await runCli(['search', 'hello world']);
+    expect(res.code).toBe(0);
+    expect(receivedQuery).toBe('hello world');
+    var data = JSON.parse(res.stdout);
+    expect(data[0].name).toBe('match');
+  });
+
+  it('categories returns JSON array', async () => {
+    await startTestServer({
+      get_categories: async () => ['code', 'design', 'web']
+    });
+    var res = await runCli(['categories']);
+    expect(res.code).toBe(0);
+    var data = JSON.parse(res.stdout);
+    expect(data).toContain('code');
+  });
+
+  it('get returns metadata JSON (not dataURL)', async () => {
+    await startTestServer({
+      get_screenshot: async () => ({
+        dataURL: 'data:image/png;base64,abc',
+        metadata: { name: 'test', category: 'code', tags: ['js'] }
+      })
+    });
+    var res = await runCli(['get', '/tmp/test.png']);
+    expect(res.code).toBe(0);
+    var data = JSON.parse(res.stdout);
+    expect(data.name).toBe('test');
+    expect(data.dataURL).toBeUndefined();
+  });
+
+  it('transcribe returns plain text, not JSON', async () => {
+    await startTestServer({
+      transcribe_screenshot: async () => ({ text: 'Hello World', languages: ['en'] })
+    });
+    var res = await runCli(['transcribe', '/tmp/test.png']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe('Hello World');
+    // Verify it's NOT JSON
+    expect(() => JSON.parse(res.stdout)).toThrow();
+  });
+
+  it('organize returns queued message', async () => {
+    await startTestServer({
+      organize_screenshot: async (params) => ({ queued: true, filepath: params.filepath })
+    });
+    var res = await runCli(['organize', '/tmp/test.png']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain('Queued');
+  });
+
+  it('open returns JSON with status, path, message', async () => {
+    var outPath = join(tmpDir, 'annotated.png');
+    writeFileSync(outPath, 'fake');
+    await startTestServer({
+      open_in_snip: async () => ({ outputPath: outPath, dataURL: 'data:image/png;base64,abc' })
+    });
+    var res = await runCli(['open', '/tmp/test.png']);
+    expect(res.code).toBe(0);
+    var data = JSON.parse(res.stdout);
+    expect(data.status).toBe('edited');
+    expect(data.path).toBe(outPath);
+    expect(data.message).toContain('annotated');
+  });
+
+  it('--pretty flag indents JSON output', async () => {
+    await startTestServer({
+      get_categories: async () => ['code', 'design']
+    });
+    var res = await runCli(['categories', '--pretty']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toContain('  "code"');
+  });
+});
+
+// ── Parameter passing ──
+
+describe('CLI parameter passing', () => {
+  it('filepath is resolved to absolute', async () => {
+    var receivedPath = null;
+    await startTestServer({
+      get_screenshot: async (params) => {
+        receivedPath = params.filepath;
+        return { metadata: { name: 'test' } };
+      }
+    });
+    var res = await runCli(['get', 'relative.png']);
+    expect(res.code).toBe(0);
+    // Should be absolute, not "relative.png"
+    expect(receivedPath).toContain('/');
+    expect(receivedPath).not.toBe('relative.png');
+  });
+
+  it('query is passed as-is', async () => {
+    var receivedQuery = null;
+    await startTestServer({
+      search_screenshots: async (params) => {
+        receivedQuery = params.query;
+        return [];
+      }
+    });
+    await runCli(['search', 'login form with spaces']);
+    expect(receivedQuery).toBe('login form with spaces');
+  });
+});
+
+// ── Socket communication ──
+
+describe('CLI socket communication', () => {
+  it('handler error → CLI exits 1 with error in stderr', async () => {
+    await startTestServer({
+      list_screenshots: async () => { throw new Error('database locked'); }
+    });
+    var res = await runCli(['list']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toContain('database locked');
+  });
+
+  it('handler returns null → CLI outputs null', async () => {
+    await startTestServer({
+      get_categories: async () => null
+    });
+    var res = await runCli(['categories']);
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe('null');
+  });
+
+  it('async handler response is received', async () => {
+    await startTestServer({
+      list_screenshots: async () => {
+        await new Promise(r => setTimeout(r, 100));
+        return [{ name: 'delayed' }];
+      }
+    });
+    var res = await runCli(['list']);
+    expect(res.code).toBe(0);
+    var data = JSON.parse(res.stdout);
+    expect(data[0].name).toBe('delayed');
+  });
+});
+
+// ── Error handling ──
+
+describe('CLI error handling', () => {
+  it('no server running → exits 1 with error', async () => {
+    // Don't start server — socket doesn't exist. SNIP_NO_AUTO_LAUNCH prevents launch attempt.
+    var res = await runCli(['list']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr.toLowerCase()).toMatch(/not running|could not be launched/);
+  });
+});
+
+// ── Open command specifics ──
+
+describe('CLI open command', () => {
+  it('result with outputPath → returns edited status JSON', async () => {
+    var outFile = join(tmpDir, 'out.png');
+    writeFileSync(outFile, 'img');
+    await startTestServer({
+      open_in_snip: async () => ({ outputPath: outFile })
+    });
+    var res = await runCli(['open', '/tmp/img.png']);
+    expect(res.code).toBe(0);
+    var data = JSON.parse(res.stdout);
+    expect(data.status).toBe('edited');
+    expect(data.path).toBe(outFile);
+  });
+
+  it('result with only dataURL → saves to temp and returns path', async () => {
+    // Minimal valid PNG (1x1 pixel)
+    var pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+    await startTestServer({
+      open_in_snip: async () => ({ dataURL: 'data:image/png;base64,' + pngBase64 })
+    });
+    var res = await runCli(['open', '/tmp/img.png']);
+    expect(res.code).toBe(0);
+    var data = JSON.parse(res.stdout);
+    expect(data.status).toBe('edited');
+    expect(data.path).toContain('.tmp');
+    expect(existsSync(data.path)).toBe(true);
+    // Clean up
+    rmSync(data.path, { force: true });
+  });
+
+  it('user cancels → exits 1 with cancelled message', async () => {
+    await startTestServer({
+      open_in_snip: async () => { throw new Error('User cancelled editing'); }
+    });
+    var res = await runCli(['open', '/tmp/img.png']);
+    expect(res.code).not.toBe(0);
+    expect(res.stderr).toContain('cancelled');
+  });
+});


### PR DESCRIPTION
 - Snip CLI: Primary interface for AI agents. snip open, snip search, snip list, snip transcribe, etc. Auto-launches
  Snip if not running. Lower token cost and higher reliability than MCP.
  - MCP server: Thin wrapper around CLI for clients that can't run shell commands (Claude Desktop). Socket always runs;
  MCP toggle controls UI visibility only.
  - AI workflow integration in Settings: Install CLI button, auto-detect AI providers (Claude Code, Cursor, Windsurf,
  Cline), one-click configure/remove with toggle state.
  - snip open round-trip: AI sends image → user annotates in editor → annotated result saved to temp → path returned to
  AI. Full human-in-the-loop flow.

![IMAGE 2026-03-16 11:15:45](https://github.com/user-attachments/assets/6f6b3c85-587d-4c1f-bd60-aeeaa5747cb6)


