### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Visual communication layer between humans and AI agents for macOS.
 
 Capture and annotate screenshots, render diagrams from code, review agent-generated visuals with approve/request-changes flow — all from the menu bar. AI organizes and indexes everything for semantic search. CLI and MCP integration let any AI agent use Snip as their visual I/O.
 
+[![Snip MCP server](https://glama.ai/mcp/servers/rixinhahaha/snip/badges/card.svg)](https://glama.ai/mcp/servers/rixinhahaha/snip)
+
 ## Install
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Snip](https://glama.ai/mcp/servers/rixinhahaha/snip) server listing in Glama MCP server directory.

[![Snip MCP server](https://glama.ai/mcp/servers/rixinhahaha/snip/badges/card.svg)](https://glama.ai/mcp/servers/rixinhahaha/snip)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.