### PR TITLE
Add aspect ratio selector to capture overlay

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -11,6 +11,14 @@
 <body>
   <img id="frozen-screen" class="hidden" />
   <canvas id="selection-overlay" class="hidden"></canvas>
+  <div id="ratio-bar" class="hidden">
+    <button class="ratio-btn active" data-ratio="free">Free</button>
+    <button class="ratio-btn" data-ratio="1:1">1:1</button>
+    <button class="ratio-btn" data-ratio="4:3">4:3</button>
+    <button class="ratio-btn" data-ratio="3:2">3:2</button>
+    <button class="ratio-btn" data-ratio="16:9">16:9</button>
+    <button class="ratio-btn" data-ratio="5:4">5:4</button>
+  </div>
   <div id="selection-hint" class="hidden">Click to screenshot the selected window · Drag to capture an area · Esc to cancel</div>
 
   <script src="tools/selection.js"></script>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -31,7 +31,7 @@ body {
 
 #selection-hint {
   position: fixed;
-  bottom: 60px;
+  bottom: 170px;
   left: 50%;
   transform: translateX(-50%);
   z-index: 701;
@@ -44,6 +44,54 @@ body {
   font-size: 14px;
   white-space: nowrap;
   pointer-events: none;
+}
+
+#ratio-bar {
+  position: fixed;
+  bottom: 110px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 702;
+  display: flex;
+  gap: 4px;
+  padding: 5px 6px;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  pointer-events: auto;
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
+#ratio-bar.ratio-bar-faded {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.ratio-btn {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.6);
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.ratio-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.ratio-btn.active {
+  background: var(--accent, #8B5CF6);
+  color: #fff;
 }
 
 .hidden {

--- a/src/renderer/tools/selection.js
+++ b/src/renderer/tools/selection.js
@@ -5,6 +5,13 @@ const SelectionTool = (() => {
     return getComputedStyle(document.documentElement).getPropertyValue('--accent').trim() || '#8B5CF6';
   }
 
+  // Parse ratio string like "4:3" into { w: 4, h: 3 }, or null for "free"
+  function parseRatio(str) {
+    if (!str || str === 'free') return null;
+    var parts = str.split(':');
+    return { w: parseInt(parts[0], 10), h: parseInt(parts[1], 10) };
+  }
+
   // States: 'idle' | 'drawing'
   function attach(canvasEl, fullWidth, fullHeight, onComplete, onCancel, windowList) {
     const overlay = document.getElementById('selection-overlay');
@@ -32,10 +39,28 @@ const SelectionTool = (() => {
     var pendingClickX = 0, pendingClickY = 0;
     var DRAG_THRESHOLD = 5; // CSS pixels (clientX/Y space)
 
+    // Aspect ratio state
+    var activeRatio = null; // null = free, or { w, h }
+    var activeRatioName = null; // display string like "16:9"
+    var ratioBar = document.getElementById('ratio-bar');
+    var ratioButtons = ratioBar ? ratioBar.querySelectorAll('.ratio-btn') : [];
+    var hint = document.getElementById('selection-hint');
+
+    function onRatioClick(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var btn = e.currentTarget;
+      var ratioStr = btn.getAttribute('data-ratio');
+      activeRatio = parseRatio(ratioStr);
+      activeRatioName = ratioStr === 'free' ? null : ratioStr;
+      // Toggle active class
+      for (var i = 0; i < ratioButtons.length; i++) {
+        ratioButtons[i].classList.remove('active');
+      }
+      btn.classList.add('active');
+    }
+
     function findWindowAt(mx, my) {
-      // Windows are in CGWindowList front-to-back z-order (frontmost first).
-      // Modern macOS reports each app window as a single entry, so no sub-window
-      // merging is needed. Just return the frontmost window containing the cursor.
       for (var i = 0; i < windows.length; i++) {
         var w = windows[i];
         if (mx >= w.x && mx < w.x + w.width && my >= w.y && my < w.y + w.height) {
@@ -43,6 +68,53 @@ const SelectionTool = (() => {
         }
       }
       return null;
+    }
+
+    function constrainToRatio(startX, startY, currentX, currentY) {
+      if (!activeRatio) return { x: currentX, y: currentY };
+
+      var dx = currentX - startX;
+      var dy = currentY - startY;
+      var absDx = Math.abs(dx);
+      var absDy = Math.abs(dy);
+
+      // Determine orientation from dominant drag direction
+      var ratioW, ratioH;
+      if (absDx >= absDy) {
+        // Landscape: use ratio as-is
+        ratioW = activeRatio.w;
+        ratioH = activeRatio.h;
+      } else {
+        // Portrait: swap ratio
+        ratioW = activeRatio.h;
+        ratioH = activeRatio.w;
+      }
+
+      // Constrain: fit the rectangle inside the drag box
+      // Try width-driven: given absDx, compute required height
+      var hFromW = absDx * ratioH / ratioW;
+      // Try height-driven: given absDy, compute required width
+      var wFromH = absDy * ratioW / ratioH;
+
+      var finalW, finalH;
+      if (hFromW <= absDy) {
+        // Width-driven fits inside drag box
+        finalW = absDx;
+        finalH = hFromW;
+      } else {
+        // Height-driven
+        finalW = wFromH;
+        finalH = absDy;
+      }
+
+      // Apply direction signs
+      var signX = dx >= 0 ? 1 : -1;
+      var signY = dy >= 0 ? 1 : -1;
+
+      return {
+        x: startX + finalW * signX,
+        y: startY + finalH * signY
+      };
     }
 
     function draw() {
@@ -58,7 +130,6 @@ const SelectionTool = (() => {
         w = Math.abs(drawCurrentX - drawStartX);
         h = Math.abs(drawCurrentY - drawStartY);
       } else if (state === 'idle' && hoveredWindow) {
-        // Highlight the window under cursor
         x = hoveredWindow.x; y = hoveredWindow.y;
         w = hoveredWindow.width; h = hoveredWindow.height;
       } else {
@@ -90,7 +161,6 @@ const SelectionTool = (() => {
 
       // Window hover: add subtle accent fill
       if (state === 'idle' && hoveredWindow) {
-        // Parse accent hex to rgba for reliable opacity
         var a = accent.trim();
         var r = parseInt(a.slice(1, 3), 16) || 139;
         var g = parseInt(a.slice(3, 5), 16) || 92;
@@ -107,6 +177,9 @@ const SelectionTool = (() => {
         if (!label) label = Math.round(w) + ' \u00d7 ' + Math.round(h);
       } else {
         label = Math.round(w) + ' \u00d7 ' + Math.round(h);
+        if (activeRatioName) {
+          label += ' (' + activeRatioName + ')';
+        }
       }
       if (w > 30 && h > 20) {
         ctx.font = '12px -apple-system, BlinkMacSystemFont, sans-serif';
@@ -138,6 +211,10 @@ const SelectionTool = (() => {
       drawCurrentX = mx;
       drawCurrentY = my;
       overlay.style.cursor = 'crosshair';
+
+      // Fade ratio bar while drawing
+      if (ratioBar) ratioBar.classList.add('ratio-bar-faded');
+
       draw();
     }
 
@@ -154,15 +231,34 @@ const SelectionTool = (() => {
             hoveredWindow = null;
           }
         }
-        drawCurrentX = mx;
-        drawCurrentY = my;
+
+        // Apply aspect ratio constraint
+        if (activeRatio) {
+          var constrained = constrainToRatio(drawStartX, drawStartY, mx, my);
+          drawCurrentX = constrained.x;
+          drawCurrentY = constrained.y;
+        } else {
+          drawCurrentX = mx;
+          drawCurrentY = my;
+        }
         draw();
-      } else if (state === 'idle' && windows.length > 0) {
-        // Highlight window under cursor
-        var win = findWindowAt(mx, my);
-        if (win !== hoveredWindow) {
-          hoveredWindow = win;
-          draw();
+      } else if (state === 'idle') {
+        // Hide hint when cursor is near the bottom bar area
+        if (hint) {
+          if (my > fullHeight - 80) {
+            hint.classList.add('hidden');
+          } else {
+            hint.classList.remove('hidden');
+          }
+        }
+
+        if (windows.length > 0) {
+          // Highlight window under cursor
+          var win = findWindowAt(mx, my);
+          if (win !== hoveredWindow) {
+            hoveredWindow = win;
+            draw();
+          }
         }
       }
     }
@@ -171,6 +267,9 @@ const SelectionTool = (() => {
       var mx = e.clientX, my = e.clientY;
 
       if (state !== 'drawing') return;
+
+      // Unfade ratio bar
+      if (ratioBar) ratioBar.classList.remove('ratio-bar-faded');
 
       // Check for window snap click (small drag = click on window)
       if (pendingClick && hoveredWindow) {
@@ -235,6 +334,16 @@ const SelectionTool = (() => {
       state = 'idle';
       overlay.classList.remove('hidden');
       overlay.style.cursor = 'crosshair';
+
+      // Show ratio bar and attach listeners
+      if (ratioBar) {
+        ratioBar.classList.remove('hidden');
+        ratioBar.classList.remove('ratio-bar-faded');
+        for (var i = 0; i < ratioButtons.length; i++) {
+          ratioButtons[i].addEventListener('click', onRatioClick);
+        }
+      }
+
       draw();
       overlay.addEventListener('mousedown', onMouseDown);
       overlay.addEventListener('mousemove', onMouseMove);
@@ -248,6 +357,24 @@ const SelectionTool = (() => {
       overlay.style.cursor = 'crosshair';
       ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.clearRect(0, 0, overlay.width, overlay.height);
+
+      // Hide ratio bar and remove listeners
+      if (ratioBar) {
+        ratioBar.classList.add('hidden');
+        for (var i = 0; i < ratioButtons.length; i++) {
+          ratioButtons[i].removeEventListener('click', onRatioClick);
+        }
+      }
+
+      // Reset ratio to free for next session
+      activeRatio = null;
+      activeRatioName = null;
+      if (ratioButtons.length) {
+        for (var j = 0; j < ratioButtons.length; j++) {
+          ratioButtons[j].classList.remove('active');
+        }
+        ratioButtons[0].classList.add('active');
+      }
     }
 
     return { activate, cleanup };


### PR DESCRIPTION
## Summary
- Adds a bottom-centered ratio bar to the area selection overlay with buttons: Free (default), 1:1, 4:3, 3:2, 16:9, 5:4
- Drag direction determines orientation automatically — horizontal drag gives landscape, vertical gives portrait
- Bar fades during drawing, intercepts clicks to prevent accidental selections, and dimension label appends ratio name when active (e.g. "640 × 360 (16:9)")

## Test plan
- [ ] Trigger capture (Cmd+Shift+2), verify ratio bar appears at bottom center
- [ ] Click each ratio button, verify active state toggles
- [ ] Select 16:9, drag horizontally — verify landscape constraint
- [ ] Select 16:9, drag vertically — verify portrait constraint
- [ ] Verify Free mode is unconstrained
- [ ] Verify bar fades while drawing and reappears on release
- [ ] Verify hint hides when cursor approaches the bar
- [ ] Verify clicking the bar doesn't start a selection
- [ ] Verify Enter full-screen capture still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)