### PR TITLE
Document aspect ratio selector feature

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -105,8 +105,8 @@ src/
     diagram-preload.js       # Minimal preload for diagram renderer window (2 IPC methods)
 
   renderer/                  # Renderer processes (no modules, globals via IIFEs)
-    index.html / app.js      # Capture overlay — fullscreen transparent region selector
-    styles.css               # Overlay-specific styles (capture selection UI)
+    index.html / app.js      # Capture overlay — fullscreen transparent region selector with aspect ratio bar
+    styles.css               # Overlay-specific styles (capture selection UI, ratio bar)
     home.html / home.js      # Gallery, search, settings UI (main window)
     home.css                 # Home window styles
     editor.html / editor-app.js  # Annotation editor
@@ -195,7 +195,7 @@ vendor/                      # Downloaded at dev time (NOT bundled in binary)
 
 | Window | File | Purpose | Lifecycle |
 |--------|------|---------|-----------|
-| **Overlay** | `index.html` | Fullscreen transparent region selection | Pre-warmed hidden at startup; reused per capture, destroyed after crop, then re-pre-warmed |
+| **Overlay** | `index.html` | Fullscreen transparent region selection with aspect ratio presets | Pre-warmed hidden at startup; reused per capture, destroyed after crop, then re-pre-warmed |
 | **Home** | `home.html` | Gallery, search, settings | Persistent singleton, hidden during capture |
 | **Editor** | `editor.html` | Annotation canvas + toolbar | Pre-warmed hidden at startup; reused per capture (resized + shown), destroyed on close, then re-pre-warmed |
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -36,7 +36,8 @@ Power users on macOS and Linux who take 5-50 screenshots per day: developers, de
 ### Capture
 - **Global shortcut** (Cmd+Shift+2 on macOS, Ctrl+Shift+2 on Linux): Fullscreen overlay, click a window to snap-select it, or drag to select a custom region — completes immediately on mouse-up
 - **Quick Snip** (Cmd+Shift+1 / Ctrl+Shift+1): Same overlay with window/region selection, copies result directly to clipboard without opening the annotation editor
-- **Full-screen capture**: Press Enter without selecting
+- **Aspect ratio selector**: Bottom-centered toolbar on the overlay with ratio presets (Free, 1:1, 4:3, 3:2, 16:9, 5:4). Drag direction determines orientation automatically — horizontal drag gives landscape (e.g. 4:3), vertical drag gives portrait (e.g. 3:4). Free mode is unconstrained. Dimension label appends ratio name when active (e.g. "640 × 360 (16:9)")
+- **Full-screen capture**: Press Enter without selecting (ignores aspect ratio)
 - Works across macOS Spaces without switching desktops (macOS only)
 - Home window hides during capture to stay out of the way
 

--- a/docs/USER_FLOWS.md
+++ b/docs/USER_FLOWS.md
@@ -54,10 +54,11 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 | 2 | -- | Screen capture (`desktopCapturer.getSources()`) and overlay window prep run in parallel; pre-warmed overlay is reused if available |
 | 3 | -- | Fullscreen transparent overlay appears on that display |
 | 4 | -- | Overlay covers entire display including menu bar |
-| 5 | -- | Cursor becomes crosshair, hint text visible: "Click to screenshot the selected window · Drag to capture an area · Esc to cancel" |
-| 5a | Move cursor over a window | Window highlighted with accent border and owner/title label (only windows with ≥50×50 visible area shown) |
+| 5 | -- | Cursor becomes crosshair, hint text visible: "Click to screenshot the selected window · Drag to capture an area · Esc to cancel". Aspect ratio bar visible below hint with presets: Free (default), 1:1, 4:3, 3:2, 16:9, 5:4 |
+| 5a | Move cursor over a window | Window highlighted with accent border and owner/title label (only windows with ≥50×50 visible area shown). Hint text hides when cursor is near the bottom bar area |
+| 5b | Click a ratio preset on the bar | Selected ratio becomes active (purple highlight). Subsequent drags are constrained to that ratio. Clicking the bar does not start a selection |
 | 6a | Click on a highlighted window | Window captured immediately, overlay closes, editor opens with cropped image |
-| 6b | Drag to select a rectangular region | On mouse-up, overlay closes and editor opens with cropped image |
+| 6b | Drag to select a rectangular region | Selection constrained to active aspect ratio (if set). Drag direction determines orientation — horizontal drag = landscape, vertical = portrait. Dimension label shows "W × H (ratio)" (e.g. "640 × 360 (16:9)"). Ratio bar fades during drag, reappears on mouse-up. On mouse-up, overlay closes and editor opens with cropped image |
 | 9 | -- | Editor window is centered on screen, min width 900px |
 | 10 | -- | Toolbar visible at top with all tools |
 
@@ -122,8 +123,8 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 
 | Step | Action | Expected Result |
 |------|--------|-----------------|
-| 1 | Press Cmd+Shift+1 (default) | Same capture overlay appears with window highlight and region selection |
-| 2 | Click a window or drag a region | Cropped image copied directly to clipboard on mouse-up — no annotation editor opens |
+| 1 | Press Cmd+Shift+1 (default) | Same capture overlay appears with window highlight, region selection, and aspect ratio bar |
+| 2 | Click a window or drag a region | Cropped image copied directly to clipboard on mouse-up — no annotation editor opens. Aspect ratio constraints apply if a ratio preset is selected |
 | 3 | -- | Floating toast "✓ Copied to clipboard" appears top-center, auto-dismisses after ~1.4s |
 
 **Edge cases:**


### PR DESCRIPTION
## Summary
- **PRODUCT.md**: Added aspect ratio selector to Capture feature list with preset descriptions and orientation behavior
- **USER_FLOWS.md**: Updated capture flow (2.1) with ratio bar steps, drag constraint behavior, bar fade, and hint hiding. Updated Quick Snip (2.3) to mention ratio bar availability
- **ARCHITECTURE.md**: Updated overlay file descriptions and Windows table to reference aspect ratio presets

## Test plan
- [ ] Review docs match the implemented behavior from #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)