### PR TITLE
Add crop tool to annotation editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,9 @@ These are non-negotiable rules. Violating them causes crashes or broken UX:
 - Two themes exist: `dark`, `light`. Changes must work in both + the solid fallback.
 - **All new UI must align with the glass design language** documented in `docs/DESIGN.md`. Before writing CSS, read the design doc for the correct variables, component patterns, and glass effect specs. Reuse existing patterns (e.g. tutorial-modal, toast pill, toolbar button states) rather than inventing new ones.
 
+### Undo Flow
+- **Every new tool must consider the undo flow.** The editor has a layered undo system: annotations undo first (object stack), then crop (crop undo stack), then segment cutout, then upscale. New tools that modify the background image or canvas dimensions must implement their own undo method (like `undoCrop()` or `undoCutout()`), save pre-operation state, and integrate into the undo priority chain in both `onUndo` callback and the Cmd+Z keydown handler in `editor-app.js`. Tools that only add Fabric objects get undo for free via the annotation stack.
+
 ### Renderer Code Style
 - **No ES modules** in renderer JS: prefer `var`, no `import`/`export`. All tools attach to `window` via IIFEs.
 - Main process uses standard CommonJS `require()`.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ On Linux, replace Cmd with Ctrl.
 | Cmd+Shift+S | Open semantic search |
 | Cmd+S | Save to disk (in editor) |
 | Esc / Enter | Copy to clipboard & close (in editor) |
-| V / R / T / A / G / B / S | Select / Rectangle / Text / Arrow / Tag / Blur / Segment tools |
+| V / C / R / T / A / G / B / S | Select / Crop / Rectangle / Text / Arrow / Tag / Blur / Segment tools |
+| Cmd+Z | Undo (annotations first, then crop, then segment cutout) |
 
 ## Development
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,7 @@ src/
     tools/
       tool-utils.js          # Shared: SEGMENT_OUTLINE_WIDTH, SEGMENT_OVERLAY_OPACITY, getAccentColor(), hexToRgba(), createMosaicImage(), recolorMaskWithOutline() (highlight fill + dilation outline), nextTagId(), lineEndpointForTag()
       selection.js           # Selection tool (move, resize, multi-select)
+      crop.js                # Crop tool (draw/adjust region, aspect ratio presets, undo support)
       rectangle.js           # Rectangle tool (outline/highlight/blur modes)
       textbox.js             # Text annotation tool
       arrow.js               # Arrow annotation tool

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -45,6 +45,7 @@ Power users on macOS and Linux who take 5-50 screenshots per day: developers, de
 | Tool | Key | Description |
 |------|-----|-------------|
 | Select | V | Move, resize, delete annotations |
+| Crop | C | Crop the captured image with optional aspect ratio presets (Free, 1:1, 4:3, 3:2, 16:9, 5:4). Drag direction determines orientation. Enter to apply, Esc to cancel. Undoable via Cmd+Z |
 | Rectangle | R | Outline, highlight, or blur modes |
 | Text | T | Editable text with font/size pickers |
 | Arrow | A | Point at things |

--- a/docs/USER_FLOWS.md
+++ b/docs/USER_FLOWS.md
@@ -137,6 +137,26 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 
 ## 3. Annotation Editor
 
+### 3.0 Crop Tool
+
+**Preconditions:** Editor open with a captured image.
+
+| Step | Action | Expected Result |
+|------|--------|-----------------|
+| 1 | Press C (or click Crop in toolbar) | Crop tool active, cursor becomes crosshair. Ratio selector appears in toolbar (Free, 1:1, 4:3, 3:2, 16:9, 5:4) |
+| 2 | (Optional) Click a ratio preset | Selected ratio highlighted with accent color |
+| 3 | Drag on the image | Crop region drawn with dashed accent border. If ratio is set, drag direction determines orientation — horizontal = landscape, vertical = portrait |
+| 4 | Release mouse | Crop region becomes adjustable (move, resize via corner handles). Dimmed overlay appears outside crop area. Action bar shows "Cancel" and "Apply Crop" buttons |
+| 5a | Press Enter or click "Apply Crop" | Image cropped to selection. Canvas resizes to new dimensions. Annotations outside crop area removed, inside ones repositioned. Tool switches to Select |
+| 5b | Press Escape or click "Cancel" | Crop cancelled, image unchanged |
+| 6 | Press Cmd+Z after crop | Crop undone — original image, dimensions, and annotations restored |
+
+**Edge cases:**
+- Crop rect < 10px in either dimension is discarded (too small)
+- Annotations are undone before crop when pressing Cmd+Z (correct priority order)
+- Changing ratio while adjusting re-constrains the existing crop rect
+- Enter key during crop adjustment does NOT trigger copy & close (capture-phase handler blocks it)
+
 ### 3.1 Rectangle Tool
 
 | Step | Action | Expected Result |

--- a/docs/USER_FLOWS.md
+++ b/docs/USER_FLOWS.md
@@ -151,9 +151,13 @@ Detailed user flows for every feature in Snip. Each flow describes preconditions
 | 5b | Press Escape or click "Cancel" | Crop cancelled, image unchanged |
 | 6 | Press Cmd+Z after crop | Crop undone — original image, dimensions, and annotations restored |
 
+**Undo behavior:**
+- Cmd+Z undoes **post-crop annotations first**, then the crop itself
+- Multiple crops stack: crop → annotate → crop again → Cmd+Z undoes second crop (restoring first crop + annotation), Cmd+Z undoes annotation, Cmd+Z undoes first crop
+- Crop undo restores the full pre-crop state: background image, canvas dimensions, and all annotations
+
 **Edge cases:**
 - Crop rect < 10px in either dimension is discarded (too small)
-- Annotations are undone before crop when pressing Cmd+Z (correct priority order)
 - Changing ratio while adjusting re-constrains the existing crop rect
 - Enter key during crop adjustment does NOT trigger copy & close (capture-phase handler blocks it)
 

--- a/src/extensions/crop/extension.json
+++ b/src/extensions/crop/extension.json
@@ -1,0 +1,12 @@
+{
+  "name": "crop",
+  "displayName": "Crop",
+  "type": "canvas-tool",
+  "toolId": "crop",
+  "icon": "<svg width=\"18\" height=\"18\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M6 2v4H2\"/><path d=\"M6 6h12v12\"/><path d=\"M18 22v-4h4\"/><path d=\"M18 18H6V6\"/></svg>",
+  "tooltip": "Crop (C)",
+  "shortcut": "c",
+  "toolbarPosition": 1.5,
+  "toolbarGroups": ["crop-ratio-group"],
+  "renderer": "../../renderer/tools/crop.js"
+}

--- a/src/extensions/extensions.json
+++ b/src/extensions/extensions.json
@@ -1,5 +1,6 @@
 [
   "select",
+  "crop",
   "rectangle",
   "text",
   "arrow",

--- a/src/renderer/editor-app.js
+++ b/src/renderer/editor-app.js
@@ -831,6 +831,14 @@
       getFontSize: Toolbar.getActiveFontSize
     });
 
+    tools['crop'] = CropTool.attach(canvas, {
+      replaceBackgroundWithResize: EditorCanvasManager.replaceBackgroundWithResize,
+      getBackground: EditorCanvasManager.getBackgroundDataURL,
+      getCssDimensions: function() { return { w: _zoomState.imgW, h: _zoomState.imgH }; },
+      scaleImageToFit: scaleImageToFit,
+      onComplete: function() { Toolbar.setTool(TOOLS.SELECT); }
+    });
+
     // Initialize animate tool (2GIF)
     AnimateTool.init();
 
@@ -983,9 +991,12 @@
         window.snip.closeEditor();
       },
       onUndo: function() {
-        // Undo annotations first, then segment, then upscale (only when canvas is empty)
+        // Annotations first, then crop, then segment, then upscale
         if (canvas && canvas.getObjects().length > 0) {
           EditorCanvasManager.removeLastObject();
+          return;
+        }
+        if (tools['crop'] && tools['crop'].undoCrop && tools['crop'].undoCrop()) {
           return;
         }
         if (tools[TOOLS.SEGMENT] && tools[TOOLS.SEGMENT].undoCutout && tools[TOOLS.SEGMENT].undoCutout()) {
@@ -1357,7 +1368,7 @@
     if (e.key === 'Enter') {
       e.preventDefault();
       var currentTool = Toolbar.getActiveTool();
-      if (currentTool === TOOLS.RECT || currentTool === TOOLS.ARROW || currentTool === TOOLS.BLUR_BRUSH) {
+      if (currentTool === TOOLS.RECT || currentTool === TOOLS.ARROW || currentTool === TOOLS.BLUR_BRUSH || currentTool === 'crop') {
         // Finish drawing session: switch to select mode
         Toolbar.setTool(TOOLS.SELECT);
       } else if (_mcpUpload) {
@@ -1392,6 +1403,9 @@
       e.preventDefault();
       if (canvas && canvas.getObjects().length > 0) {
         EditorCanvasManager.removeLastObject();
+        return;
+      }
+      if (tools['crop'] && tools['crop'].undoCrop && tools['crop'].undoCrop()) {
         return;
       }
       if (tools[TOOLS.SEGMENT] && tools[TOOLS.SEGMENT].undoCutout && tools[TOOLS.SEGMENT].undoCutout()) {

--- a/src/renderer/editor-app.js
+++ b/src/renderer/editor-app.js
@@ -991,12 +991,12 @@
         window.snip.closeEditor();
       },
       onUndo: function() {
-        // Annotations first, then crop, then segment, then upscale
-        if (canvas && canvas.getObjects().length > 0) {
-          EditorCanvasManager.removeLastObject();
+        // Crop undo checks internally if post-crop annotations are cleared
+        if (tools['crop'] && tools['crop'].undoCrop && tools['crop'].undoCrop()) {
           return;
         }
-        if (tools['crop'] && tools['crop'].undoCrop && tools['crop'].undoCrop()) {
+        if (canvas && canvas.getObjects().length > 0) {
+          EditorCanvasManager.removeLastObject();
           return;
         }
         if (tools[TOOLS.SEGMENT] && tools[TOOLS.SEGMENT].undoCutout && tools[TOOLS.SEGMENT].undoCutout()) {
@@ -1401,11 +1401,11 @@
 
     if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
       e.preventDefault();
-      if (canvas && canvas.getObjects().length > 0) {
-        EditorCanvasManager.removeLastObject();
+      if (tools['crop'] && tools['crop'].undoCrop && tools['crop'].undoCrop()) {
         return;
       }
-      if (tools['crop'] && tools['crop'].undoCrop && tools['crop'].undoCrop()) {
+      if (canvas && canvas.getObjects().length > 0) {
+        EditorCanvasManager.removeLastObject();
         return;
       }
       if (tools[TOOLS.SEGMENT] && tools[TOOLS.SEGMENT].undoCutout && tools[TOOLS.SEGMENT].undoCutout()) {

--- a/src/renderer/editor-canvas-manager.js
+++ b/src/renderer/editor-canvas-manager.js
@@ -164,9 +164,15 @@ const EditorCanvasManager = (() => {
 
   function getCanvas() { return canvas; }
 
+  function replaceBackgroundWithResize(dataURL, newCssW, newCssH) {
+    cssW = newCssW;
+    cssH = newCssH;
+    applyBackground(dataURL, newCssW, newCssH);
+  }
+
   function getBackgroundDataURL() {
     return physImageEl ? physImageEl.src : null;
   }
 
-  return { initCanvas, setBackgroundImage, replaceBackground, resetToOriginal, exportAsDataURL, clearAnnotations, removeLastObject, redoLastObject, getCanvas, getBackgroundDataURL };
+  return { initCanvas, setBackgroundImage, replaceBackground, replaceBackgroundWithResize, resetToOriginal, exportAsDataURL, clearAnnotations, removeLastObject, redoLastObject, getCanvas, getBackgroundDataURL };
 })();

--- a/src/renderer/editor-styles.css
+++ b/src/renderer/editor-styles.css
@@ -427,6 +427,37 @@ select:hover {
   color: var(--segment-reject-hover-text);
 }
 
+/* Crop ratio selector in toolbar */
+#crop-ratio-bar {
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-input);
+  border-radius: 6px;
+}
+
+.crop-ratio-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.crop-ratio-btn:hover {
+  color: var(--text-primary);
+}
+
+.crop-ratio-btn.active {
+  background: var(--accent);
+  color: white;
+}
+
 .segment-action-btn.tag-segment {
   background: var(--accent);
   color: white;

--- a/src/renderer/editor.html
+++ b/src/renderer/editor.html
@@ -84,6 +84,17 @@
             <option value="40">Large</option>
           </select>
         </div>
+        <div id="crop-ratio-group" class="toolbar-group hidden">
+          <span class="toolbar-label">Ratio</span>
+          <div id="crop-ratio-bar">
+            <button class="crop-ratio-btn active" data-ratio="free">Free</button>
+            <button class="crop-ratio-btn" data-ratio="1:1">1:1</button>
+            <button class="crop-ratio-btn" data-ratio="4:3">4:3</button>
+            <button class="crop-ratio-btn" data-ratio="3:2">3:2</button>
+            <button class="crop-ratio-btn" data-ratio="16:9">16:9</button>
+            <button class="crop-ratio-btn" data-ratio="5:4">5:4</button>
+          </div>
+        </div>
         <div class="toolbar-separator"></div>
         <button id="btn-undo" class="tool-btn" data-tooltip="Undo (⌘Z)">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -127,6 +138,12 @@
           </svg>
         </button>
       </div>
+    </div>
+
+    <!-- Crop action bar -->
+    <div id="crop-actions" class="segment-actions hidden">
+      <button id="crop-cancel" class="segment-action-btn reject">Cancel <kbd>Esc</kbd></button>
+      <button id="crop-apply" class="segment-action-btn accept">Apply Crop <kbd>Enter</kbd></button>
     </div>
 
     <!-- Segment accept/reject/tag action bar -->
@@ -443,6 +460,7 @@
   <script src="extension-loader.js"></script>
   <script src="toolbar.js"></script>
   <script src="tools/tool-utils.js"></script>
+  <script src="tools/crop.js"></script>
   <script src="tools/rectangle.js"></script>
   <script src="tools/textbox.js"></script>
   <script src="tools/arrow.js"></script>

--- a/src/renderer/toolbar.js
+++ b/src/renderer/toolbar.js
@@ -190,7 +190,7 @@ const Toolbar = (() => {
     }
 
     // Show/hide contextual controls based on extension toolbar groups
-    var allGroups = ['rect-mode-group', 'stroke-group', 'font-group', 'tag-color-group', 'brush-group', 'segment-color-group'];
+    var allGroups = ['rect-mode-group', 'stroke-group', 'font-group', 'tag-color-group', 'brush-group', 'segment-color-group', 'crop-ratio-group'];
     var activeGroups = (typeof ExtensionLoader !== 'undefined')
       ? ExtensionLoader.getToolbarGroups(tool)
       : [];

--- a/src/renderer/tools/crop.js
+++ b/src/renderer/tools/crop.js
@@ -1,0 +1,542 @@
+/* global fabric, ToolUtils */
+/* exported CropTool */
+
+const CropTool = (() => {
+  function parseRatio(str) {
+    if (!str || str === 'free') return null;
+    var parts = str.split(':');
+    return { w: parseInt(parts[0], 10), h: parseInt(parts[1], 10) };
+  }
+
+  function attach(canvas, callbacks) {
+    var state = 'idle'; // 'idle' | 'drawing' | 'adjusting'
+    var cropRect = null;
+    var startX = 0, startY = 0;
+    var keyHandler = null;
+    var preCropState = null;
+
+    // Aspect ratio state
+    var activeRatio = null;
+    var activeRatioName = null;
+
+    var actionsEl = document.getElementById('crop-actions');
+    var applyBtn = document.getElementById('crop-apply');
+    var cancelBtn = document.getElementById('crop-cancel');
+    var ratioBar = document.getElementById('crop-ratio-bar');
+    var ratioButtons = ratioBar ? ratioBar.querySelectorAll('.crop-ratio-btn') : [];
+
+    var dimOverlay = null;
+
+    function getAccent() {
+      return ToolUtils.getAccentColor();
+    }
+
+    function getCssDims() {
+      return callbacks.getCssDimensions();
+    }
+
+    // --- Ratio ---
+
+    function onRatioClick(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var btn = e.currentTarget;
+      var ratioStr = btn.getAttribute('data-ratio');
+      activeRatio = parseRatio(ratioStr);
+      activeRatioName = ratioStr === 'free' ? null : ratioStr;
+      for (var i = 0; i < ratioButtons.length; i++) {
+        ratioButtons[i].classList.remove('active');
+      }
+      btn.classList.add('active');
+
+      if (state === 'adjusting' && cropRect && activeRatio) {
+        reconstrainCropRect();
+      }
+    }
+
+    function reconstrainCropRect() {
+      if (!cropRect || !activeRatio) return;
+      var dims = getCssDims();
+      var w = cropRect.width * (cropRect.scaleX || 1);
+      var h = cropRect.height * (cropRect.scaleY || 1);
+
+      var ratioW, ratioH;
+      if (w >= h) {
+        ratioW = activeRatio.w;
+        ratioH = activeRatio.h;
+      } else {
+        ratioW = activeRatio.h;
+        ratioH = activeRatio.w;
+      }
+
+      var newW, newH;
+      var hFromW = w * ratioH / ratioW;
+      if (hFromW <= h) {
+        newW = w;
+        newH = hFromW;
+      } else {
+        newH = h;
+        newW = h * ratioW / ratioH;
+      }
+
+      if (cropRect.left + newW > dims.w) newW = dims.w - cropRect.left;
+      if (cropRect.top + newH > dims.h) newH = dims.h - cropRect.top;
+
+      cropRect.set({ width: newW, height: newH, scaleX: 1, scaleY: 1 });
+      cropRect.setCoords();
+      updateDimOverlay();
+      canvas.renderAll();
+    }
+
+    function constrainToRatio(sX, sY, curX, curY) {
+      if (!activeRatio) return { x: curX, y: curY };
+
+      var dx = curX - sX;
+      var dy = curY - sY;
+      var absDx = Math.abs(dx);
+      var absDy = Math.abs(dy);
+
+      var ratioW, ratioH;
+      if (absDx >= absDy) {
+        ratioW = activeRatio.w;
+        ratioH = activeRatio.h;
+      } else {
+        ratioW = activeRatio.h;
+        ratioH = activeRatio.w;
+      }
+
+      var hFromW = absDx * ratioH / ratioW;
+      var wFromH = absDy * ratioW / ratioH;
+
+      var finalW, finalH;
+      if (hFromW <= absDy) {
+        finalW = absDx;
+        finalH = hFromW;
+      } else {
+        finalW = wFromH;
+        finalH = absDy;
+      }
+
+      return {
+        x: sX + finalW * (dx >= 0 ? 1 : -1),
+        y: sY + finalH * (dy >= 0 ? 1 : -1)
+      };
+    }
+
+    // --- Dim overlay ---
+
+    function createDimOverlay() {
+      removeDimOverlay();
+      dimOverlay = document.createElement('div');
+      dimOverlay.id = 'crop-dim-overlay';
+      dimOverlay.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);pointer-events:none;z-index:1;';
+      var imageArea = document.getElementById('image-area');
+      if (imageArea) imageArea.appendChild(dimOverlay);
+      updateDimOverlay();
+    }
+
+    function updateDimOverlay() {
+      if (!dimOverlay || !cropRect) return;
+      var dims = getCssDims();
+
+      var cl = cropRect.left;
+      var ct = cropRect.top;
+      var cw = cropRect.width * (cropRect.scaleX || 1);
+      var ch = cropRect.height * (cropRect.scaleY || 1);
+
+      var lp = (cl / dims.w * 100);
+      var tp = (ct / dims.h * 100);
+      var rp = ((cl + cw) / dims.w * 100);
+      var bp = ((ct + ch) / dims.h * 100);
+
+      dimOverlay.style.clipPath =
+        'polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%, 0% 0%, ' +
+        lp + '% ' + tp + '%, ' +
+        lp + '% ' + bp + '%, ' +
+        rp + '% ' + bp + '%, ' +
+        rp + '% ' + tp + '%, ' +
+        lp + '% ' + tp + '%)';
+    }
+
+    function removeDimOverlay() {
+      if (dimOverlay && dimOverlay.parentNode) {
+        dimOverlay.parentNode.removeChild(dimOverlay);
+      }
+      dimOverlay = null;
+    }
+
+    // --- Actions ---
+
+    function showActions() {
+      if (actionsEl) actionsEl.classList.remove('hidden');
+    }
+
+    function hideActions() {
+      if (actionsEl) actionsEl.classList.add('hidden');
+    }
+
+    // --- Key handler (capture phase, blocks global Enter/Esc) ---
+
+    function attachKeyHandler() {
+      if (keyHandler) return;
+      keyHandler = function(e) {
+        // Only intercept when we have a crop rect to apply or cancel
+        if (state !== 'adjusting') return;
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          e.stopPropagation();
+          applyCrop();
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          e.stopPropagation();
+          cancelCrop();
+        }
+      };
+      document.addEventListener('keydown', keyHandler, true);
+    }
+
+    function detachKeyHandler() {
+      if (keyHandler) {
+        document.removeEventListener('keydown', keyHandler, true);
+        keyHandler = null;
+      }
+    }
+
+    // --- Crop logic ---
+
+    function applyCrop() {
+      if (!cropRect) return;
+
+      var dims = getCssDims();
+
+      // Save pre-crop state — filter out crop overlay objects from JSON
+      var cropOverlayObjs = canvas.getObjects().filter(function(o) { return o._snipCropOverlay; });
+      cropOverlayObjs.forEach(function(o) { canvas.remove(o); });
+      var cleanJSON = canvas.toJSON();
+      cropOverlayObjs.forEach(function(o) { canvas.add(o); });
+
+      preCropState = {
+        bgDataURL: callbacks.getBackground(),
+        cssW: dims.w,
+        cssH: dims.h,
+        canvasJSON: cleanJSON
+      };
+
+      var cropX = Math.max(0, Math.round(cropRect.left));
+      var cropY = Math.max(0, Math.round(cropRect.top));
+      var cropW = Math.min(Math.round(cropRect.width * (cropRect.scaleX || 1)), dims.w - cropX);
+      var cropH = Math.min(Math.round(cropRect.height * (cropRect.scaleY || 1)), dims.h - cropY);
+
+      if (cropW < 1 || cropH < 1) {
+        cancelCrop();
+        return;
+      }
+
+      var bgImg = canvas._bgOriginalImg;
+      if (!bgImg) {
+        cancelCrop();
+        return;
+      }
+
+      var scaleX = bgImg.naturalWidth / dims.w;
+      var scaleY = bgImg.naturalHeight / dims.h;
+
+      var physX = Math.round(cropX * scaleX);
+      var physY = Math.round(cropY * scaleY);
+      var physW = Math.round(cropW * scaleX);
+      var physH = Math.round(cropH * scaleY);
+
+      var offscreen = document.createElement('canvas');
+      offscreen.width = physW;
+      offscreen.height = physH;
+      var ctx = offscreen.getContext('2d');
+      ctx.drawImage(bgImg, physX, physY, physW, physH, 0, 0, physW, physH);
+      var croppedDataURL = offscreen.toDataURL('image/png');
+
+      removeCropUI();
+
+      var objects = canvas.getObjects().slice();
+      objects.forEach(function(obj) {
+        if (obj._snipCropOverlay) return;
+        var objLeft = obj.left;
+        var objTop = obj.top;
+        var objW = obj.width * (obj.scaleX || 1);
+        var objH = obj.height * (obj.scaleY || 1);
+
+        if (objLeft >= cropX + cropW || objLeft + objW <= cropX ||
+            objTop >= cropY + cropH || objTop + objH <= cropY) {
+          canvas.remove(obj);
+        } else {
+          obj.set({ left: obj.left - cropX, top: obj.top - cropY });
+          obj.setCoords();
+        }
+      });
+
+      callbacks.replaceBackgroundWithResize(croppedDataURL, cropW, cropH);
+      canvas.setDimensions({ width: cropW, height: cropH });
+      callbacks.scaleImageToFit(cropW, cropH);
+      canvas.renderAll();
+
+      state = 'idle';
+      callbacks.onComplete();
+    }
+
+    function cancelCrop() {
+      removeCropUI();
+      state = 'idle';
+      canvas.selection = true;
+      canvas.defaultCursor = 'default';
+      canvas.hoverCursor = 'move';
+      canvas.renderAll();
+    }
+
+    function removeCropUI() {
+      if (cropRect) {
+        canvas.remove(cropRect);
+        cropRect = null;
+      }
+      removeDimOverlay();
+      hideActions();
+      detachKeyHandler();
+      canvas.off('object:moving', onCropMoving);
+      canvas.off('object:scaling', onCropScaling);
+    }
+
+    // --- Constrain crop rect ---
+
+    function onCropMoving(opt) {
+      if (opt.target !== cropRect) return;
+      var dims = getCssDims();
+      var obj = opt.target;
+      var w = obj.width * (obj.scaleX || 1);
+      var h = obj.height * (obj.scaleY || 1);
+
+      if (obj.left < 0) obj.set('left', 0);
+      if (obj.top < 0) obj.set('top', 0);
+      if (obj.left + w > dims.w) obj.set('left', dims.w - w);
+      if (obj.top + h > dims.h) obj.set('top', dims.h - h);
+
+      updateDimOverlay();
+    }
+
+    function onCropScaling(opt) {
+      if (opt.target !== cropRect) return;
+      var dims = getCssDims();
+      var obj = opt.target;
+
+      var l = obj.left;
+      var t = obj.top;
+      var r = l + obj.width * (obj.scaleX || 1);
+      var b = t + obj.height * (obj.scaleY || 1);
+
+      if (l < 0 || t < 0 || r > dims.w || b > dims.h) {
+        obj.set({
+          left: Math.max(0, l),
+          top: Math.max(0, t),
+          scaleX: (Math.min(dims.w, r) - Math.max(0, l)) / obj.width,
+          scaleY: (Math.min(dims.h, b) - Math.max(0, t)) / obj.height
+        });
+      }
+
+      if (activeRatio) {
+        var curW = obj.width * (obj.scaleX || 1);
+        var curH = obj.height * (obj.scaleY || 1);
+        var ratioW, ratioH;
+        if (curW >= curH) {
+          ratioW = activeRatio.w;
+          ratioH = activeRatio.h;
+        } else {
+          ratioW = activeRatio.h;
+          ratioH = activeRatio.w;
+        }
+        var newH2 = curW * ratioH / ratioW;
+        obj.set({ width: curW, height: newH2, scaleX: 1, scaleY: 1 });
+      }
+
+      updateDimOverlay();
+    }
+
+    // --- Mouse handlers ---
+
+    function onMouseDown(opt) {
+      if (state === 'adjusting') return;
+      if (opt.target && !opt.target._snipCropOverlay) return;
+
+      var pointer = ToolUtils.clampedScenePoint(canvas, opt.e);
+      state = 'drawing';
+      startX = pointer.x;
+      startY = pointer.y;
+
+      var accent = getAccent();
+      cropRect = new fabric.Rect({
+        left: startX,
+        top: startY,
+        width: 0,
+        height: 0,
+        fill: 'transparent',
+        stroke: accent,
+        strokeWidth: 2,
+        strokeDashArray: [6, 3],
+        strokeUniform: true,
+        originX: 'left',
+        originY: 'top',
+        selectable: false,
+        evented: false,
+        excludeFromExport: true,
+        _snipCropOverlay: true
+      });
+      canvas.add(cropRect);
+    }
+
+    function onMouseMove(opt) {
+      if (state !== 'drawing' || !cropRect) return;
+      var pointer = ToolUtils.clampedScenePoint(canvas, opt.e);
+
+      var curX = pointer.x;
+      var curY = pointer.y;
+
+      if (activeRatio) {
+        var constrained = constrainToRatio(startX, startY, curX, curY);
+        curX = constrained.x;
+        curY = constrained.y;
+      }
+
+      var left = Math.min(startX, curX);
+      var top = Math.min(startY, curY);
+      var width = Math.abs(curX - startX);
+      var height = Math.abs(curY - startY);
+
+      cropRect.set({ left: left, top: top, width: width, height: height });
+      cropRect.setCoords();
+      canvas.renderAll();
+    }
+
+    function onMouseUp() {
+      if (state !== 'drawing' || !cropRect) return;
+
+      if (cropRect.width < 10 || cropRect.height < 10) {
+        canvas.remove(cropRect);
+        cropRect = null;
+        state = 'idle';
+        canvas.renderAll();
+        return;
+      }
+
+      state = 'adjusting';
+
+      cropRect.set({
+        selectable: true,
+        evented: true,
+        hasControls: true,
+        hasBorders: true,
+        lockRotation: true,
+        cornerColor: 'white',
+        cornerStrokeColor: getAccent(),
+        cornerSize: 10,
+        cornerStyle: 'circle',
+        transparentCorners: false,
+        borderColor: getAccent()
+      });
+      cropRect.setCoords();
+      canvas.setActiveObject(cropRect);
+
+      createDimOverlay();
+
+      canvas.on('object:moving', onCropMoving);
+      canvas.on('object:scaling', onCropScaling);
+
+      // Show apply/cancel now that there's a crop to apply
+      showActions();
+      attachKeyHandler();
+
+      canvas.renderAll();
+    }
+
+    function onApplyClick() { applyCrop(); }
+    function onCancelClick() { cancelCrop(); }
+
+    return {
+      activate: function() {
+        state = 'idle';
+        canvas.selection = false;
+        canvas.defaultCursor = 'crosshair';
+        canvas.hoverCursor = 'crosshair';
+        canvas.discardActiveObject();
+
+        // Force crosshair on the upper-canvas element
+        var upperCanvas = canvas.upperCanvasEl || canvas.wrapperEl;
+        if (upperCanvas) upperCanvas.style.cursor = 'crosshair';
+
+        canvas.renderAll();
+
+        canvas.on('mouse:down', onMouseDown);
+        canvas.on('mouse:move', onMouseMove);
+        canvas.on('mouse:up', onMouseUp);
+
+        if (applyBtn) applyBtn.addEventListener('click', onApplyClick);
+        if (cancelBtn) cancelBtn.addEventListener('click', onCancelClick);
+        for (var i = 0; i < ratioButtons.length; i++) {
+          ratioButtons[i].addEventListener('click', onRatioClick);
+        }
+
+        // Show the action bar immediately so user can pick ratio before drawing
+        showActions();
+      },
+
+      deactivate: function() {
+        removeCropUI();
+
+        canvas.off('mouse:down', onMouseDown);
+        canvas.off('mouse:move', onMouseMove);
+        canvas.off('mouse:up', onMouseUp);
+
+        if (applyBtn) applyBtn.removeEventListener('click', onApplyClick);
+        if (cancelBtn) cancelBtn.removeEventListener('click', onCancelClick);
+        for (var i = 0; i < ratioButtons.length; i++) {
+          ratioButtons[i].removeEventListener('click', onRatioClick);
+        }
+
+        activeRatio = null;
+        activeRatioName = null;
+        for (var j = 0; j < ratioButtons.length; j++) {
+          ratioButtons[j].classList.remove('active');
+        }
+        if (ratioButtons.length) ratioButtons[0].classList.add('active');
+
+        state = 'idle';
+        canvas.selection = true;
+        canvas.defaultCursor = 'default';
+        canvas.hoverCursor = 'move';
+        canvas.renderAll();
+      },
+
+      undoCrop: function() {
+        if (!preCropState) return false;
+        var s = preCropState;
+        preCropState = null;
+
+        // Restore background and dimensions
+        callbacks.replaceBackgroundWithResize(s.bgDataURL, s.cssW, s.cssH);
+        canvas.setDimensions({ width: s.cssW, height: s.cssH });
+
+        // Clear current annotations and restore saved ones
+        canvas.getObjects().slice().forEach(function(obj) { canvas.remove(obj); });
+
+        var afterRestore = function() {
+          callbacks.scaleImageToFit(s.cssW, s.cssH);
+          canvas.renderAll();
+        };
+
+        if (s.canvasJSON) {
+          canvas.loadFromJSON(s.canvasJSON).then(afterRestore);
+        } else {
+          afterRestore();
+        }
+
+        return true;
+      }
+    };
+  }
+
+  return { attach };
+})();

--- a/src/renderer/tools/crop.js
+++ b/src/renderer/tools/crop.js
@@ -13,7 +13,7 @@ const CropTool = (() => {
     var cropRect = null;
     var startX = 0, startY = 0;
     var keyHandler = null;
-    var preCropState = null;
+    var cropUndoStack = []; // stack of { state, postObjectCount }
 
     // Aspect ratio state
     var activeRatio = null;
@@ -210,17 +210,13 @@ const CropTool = (() => {
       var dims = getCssDims();
 
       // Save pre-crop state — filter out crop overlay objects from JSON
+      var preBgDataURL = callbacks.getBackground();
+      var preCssW = dims.w;
+      var preCssH = dims.h;
       var cropOverlayObjs = canvas.getObjects().filter(function(o) { return o._snipCropOverlay; });
       cropOverlayObjs.forEach(function(o) { canvas.remove(o); });
       var cleanJSON = canvas.toJSON();
       cropOverlayObjs.forEach(function(o) { canvas.add(o); });
-
-      preCropState = {
-        bgDataURL: callbacks.getBackground(),
-        cssW: dims.w,
-        cssH: dims.h,
-        canvasJSON: cleanJSON
-      };
 
       var cropX = Math.max(0, Math.round(cropRect.left));
       var cropY = Math.max(0, Math.round(cropRect.top));
@@ -276,6 +272,15 @@ const CropTool = (() => {
       canvas.setDimensions({ width: cropW, height: cropH });
       callbacks.scaleImageToFit(cropW, cropH);
       canvas.renderAll();
+
+      // Push pre-crop state to undo stack with post-crop object count
+      cropUndoStack.push({
+        bgDataURL: preBgDataURL,
+        cssW: preCssW,
+        cssH: preCssH,
+        canvasJSON: cleanJSON,
+        postObjectCount: canvas.getObjects().length
+      });
 
       state = 'idle';
       callbacks.onComplete();
@@ -511,9 +516,11 @@ const CropTool = (() => {
       },
 
       undoCrop: function() {
-        if (!preCropState) return false;
-        var s = preCropState;
-        preCropState = null;
+        if (cropUndoStack.length === 0) return false;
+        var top = cropUndoStack[cropUndoStack.length - 1];
+        // Only undo crop when all post-crop annotations have been undone
+        if (canvas.getObjects().length > top.postObjectCount) return false;
+        var s = cropUndoStack.pop();
 
         // Restore background and dimensions
         callbacks.replaceBackgroundWithResize(s.bgDataURL, s.cssW, s.cssH);


### PR DESCRIPTION
## Summary
- New **Crop tool** (C key) in the editor toolbar with aspect ratio presets (Free, 1:1, 4:3, 3:2, 16:9, 5:4)
- Drag direction determines orientation — horizontal = landscape, vertical = portrait
- Adjustable crop region with dimmed overlay, Apply/Cancel action bar, Enter/Esc keyboard shortcuts
- Full undo support (Cmd+Z) with correct priority: annotations undo before crop undo
- Capture-phase Enter handler prevents global copy & close during crop mode

## Test plan
- [ ] Press C or click crop button — verify crosshair cursor and ratio selector in toolbar
- [ ] Draw crop region — verify dashed border and dim overlay outside selection
- [ ] Select 16:9 ratio, drag horizontally — verify landscape constraint
- [ ] Select 16:9 ratio, drag vertically — verify portrait constraint
- [ ] Move/resize crop region — verify overlay updates and stays within canvas bounds
- [ ] Press Enter or click Apply — verify image crops correctly and canvas resizes
- [ ] Add annotations after crop, Cmd+Z — verify annotations undo first
- [ ] Cmd+Z again — verify crop undoes (original image + dimensions restored)
- [ ] Press Esc during crop — verify cancel without closing editor
- [ ] Verify Enter key after crop tool deactivate works normally (copy & close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)